### PR TITLE
add missing ZZPhaseToRz pass

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -369,6 +369,7 @@ class QuantinuumBackend(Backend):
                     NormaliseTK2(),
                     DecomposeTK2(**fidelities),
                     self.rebase_pass(),
+                    ZZPhaseToRz(),
                     RemoveRedundancies(),
                     squash,
                     SimplifyInitial(


### PR DESCRIPTION
Added the `ZZPhaseToRz` pass to the `default_compilation_pass` at optimisation_level=2 per the recent issue https://github.com/CQCL/pytket-quantinuum/issues/48 . 

If there is anything else to be added let me know.