### PR TITLE
Use `actions/deploy-pages` to publish docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,8 +109,8 @@ jobs:
         password: ${{ secrets.PYPI_PYTKET_QUANTINUUM_API_TOKEN }}
         verbose: true
 
-  docs:
-    name: Build and publish docs
+  build_docs:
+    name: Build docs
     if: github.event_name == 'release'
     needs: publish_to_pypi
     runs-on: ubuntu-22.04
@@ -138,20 +138,24 @@ jobs:
       run: |
         cd .github/workflows/docs
         mkdir extensions
-        ./build-docs -d ${GITHUB_WORKSPACE}/.github/workflows/docs/extensions
-    - name: Configure git
-      run: |
-        git config --global user.email "tket-bot@cambridgequantum.com"
-        git config --global user.name  "«$GITHUB_WORKFLOW» github action"
-    - name: Check out gh-pages branch
-      run: git checkout gh-pages
-    - name: Remove old docs
-      run: git rm -r --ignore-unmatch docs/api
-    - name: Add generated docs to repository
-      run: |
-        mkdir -p docs
-        mv .github/workflows/docs/extensions docs/api
-        git add -f docs/api
-        git commit --allow-empty -m "Add generated documentation."
-    - name: Publish docs
-      run:  git push origin gh-pages:gh-pages
+        ./build-docs -d ${GITHUB_WORKSPACE}/.github/workflows/docs/extensions/api
+    - name: Upload docs as artefact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: .github/workflows/docs/extensions
+
+  publish_docs:
+    name: Publish docs
+    if: github.event_name == 'release'
+    needs: build_docs
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1


### PR DESCRIPTION
This is a new way to publish to github pages that doesn't use the special `gh-pages` branch.

It is still officially "beta" but seems to work.

Requires a modification to the repo "Pages" settings to enable it. (I modified the settings to test it, and have now reverted them, but will switch back once this is merged).

Tested here: https://github.com/CQCL/pytket-quantinuum/actions/runs/3468800329
Docs successfully uploaded: https://cqcl.github.io/pytket-quantinuum/api/index.html