### PR TITLE
Ensure tests are ready for H2

### DIFF
--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -542,6 +542,19 @@ class QuantinuumAPIOffline:
                     "batching": True,
                     "wasm": True,
                 },
+                {
+                    "name": "H2-1",
+                    "n_qubits": 32,
+                    "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+                    "n_classical_registers": 50,
+                    "n_shots": 10000,
+                    "system_family": "H2",
+                    "system_type": "hardware",
+                    "emulator": "H2-1E",
+                    "syntax_checker": "H2-1SC",
+                    "batching": True,
+                    "wasm": True,
+                },
             ]
         self.provider = ""
         self.url = ""

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -66,7 +66,6 @@ from pytket.extensions.quantinuum.backends.credential_storage import (
 from .api_wrappers import QuantinuumAPIError, QuantinuumAPI
 
 _DEBUG_HANDLE_PREFIX = "_MACHINE_DEBUG_"
-QUANTINUUM_URL_PREFIX = "https://qapi.quantinuum.com/"
 DEVICE_FAMILY = "H1"
 MAX_C_REG_WIDTH = 32
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -66,7 +66,6 @@ from pytket.extensions.quantinuum.backends.credential_storage import (
 from .api_wrappers import QuantinuumAPIError, QuantinuumAPI
 
 _DEBUG_HANDLE_PREFIX = "_MACHINE_DEBUG_"
-DEVICE_FAMILY = "H1"
 MAX_C_REG_WIDTH = 32
 
 _STATUS_MAP = {

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -45,11 +45,7 @@ from pytket.circuit import (  # type: ignore
     if_not_bit,
 )
 from pytket.extensions.quantinuum import QuantinuumBackend
-from pytket.extensions.quantinuum.backends.quantinuum import (
-    DEVICE_FAMILY,
-    GetResultFailed,
-    _GATE_SET,
-)
+from pytket.extensions.quantinuum.backends.quantinuum import GetResultFailed, _GATE_SET
 from pytket.extensions.quantinuum.backends.api_wrappers import (
     QuantinuumAPIError,
     QuantinuumAPI,
@@ -324,11 +320,11 @@ def test_cost_estimate(
 ) -> None:
     b = authenticated_quum_backend
     c = b.get_compiled_circuit(c)
-    if b._device_name == DEVICE_FAMILY:
+    if b._device_name in ["H1", "H2"]:
         with pytest.raises(ValueError) as e:
             _ = b.cost(c, n_shots)
         assert "Cannot find syntax checker" in str(e.value)
-        estimate = b.cost(c, n_shots, syntax_checker="H1-1SC")
+        estimate = b.cost(c, n_shots, syntax_checker=f"{b._device_name}-1SC")
     else:
         estimate = b.cost(c, n_shots)
     if estimate is None:


### PR DESCRIPTION
When the H2 is released we should add more tests for it; this PR is just to make sure the existing tests continue to work. (Also add H2-1 to the "offline" API, and remove an unused variable.)