### PR TITLE
Revert "Use pytket 1.11.0rc0."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.11.0rc0",
+        "pytket ~= 1.10",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",


### PR DESCRIPTION
This reverts commit d11bf9eb05ba80cffb539d5b18c296073ddcce4f.

This was a mistake in my last PR: the CI always picks up the latest pre-release when testing.