### PR TITLE
prevent docs theme upgrade for now

### DIFF
--- a/.github/workflows/docs/requirements.txt
+++ b/.github/workflows/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx ~= 4.3.2
 sphinx_book_theme ~= 0.3.3
-sphinx-copybutton 
+sphinx-copybutton

--- a/.github/workflows/docs/requirements.txt
+++ b/.github/workflows/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx ~= 4.3.2
-sphinx_book_theme
-sphinx-copybutton
+sphinx_book_theme ~= 0.3.3
+sphinx-copybutton 


### PR DESCRIPTION
Preventing an upgrade to the new 1.0+ version of sphinx_book_theme for now

I think we should make documentation compatible with sphinx_book_theme v1.0+ for the next release