### PR TITLE
Experimental QIR support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,7 +3,7 @@ API documentation
 
 .. automodule:: pytket.extensions.quantinuum
     :special-members:
-    :members: QuantinuumBackend, QuantinuumAPI, QuantinuumAPIOffline
+    :members: QuantinuumBackend, QuantinuumAPI, QuantinuumAPIOffline, Language
 
 .. automodule:: pytket.extensions.quantinuum.backends.config
     :members:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Add ``Language`` enum to control language used for circuit submission, with
+  values ``Language.QASM`` and ``Language.QIR``.
+* Renamed ``QuantinuumBackend.submit_qasm()`` to
+  ``QuantinuumBackend.submit_program()``, with a ``language`` argument.
+* Add a ``language`` kwarg to ``QuantinuumBackend.process_circuits()``,
+  defaulting to ``Language.QASM``. (Support for ``Language.QIR`` is
+  experimental and its use is not recommended; a warning will be emitted.)
+
 0.16.0 (May 2023)
 -----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,9 @@ Unreleased
   ``QuantinuumBackend.submit_program()``, with a ``language`` argument.
 * Add a ``language`` kwarg to ``QuantinuumBackend.process_circuits()``,
   defaulting to ``Language.QASM``. (Support for ``Language.QIR`` is
-  experimental and its use is not recommended; a warning will be emitted.)
+  experimental and its use is not recommended; a warning will be emitted. You
+  must install the ``pytket-qir`` package separately in order to use this
+  feature.)
 
 0.16.0 (May 2023)
 -----------------

--- a/pytket/extensions/quantinuum/__init__.py
+++ b/pytket/extensions/quantinuum/__init__.py
@@ -17,4 +17,4 @@
 
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_version__, __extension_name__  # type: ignore
-from .backends import QuantinuumBackend, QuantinuumAPI, QuantinuumAPIOffline
+from .backends import QuantinuumBackend, QuantinuumAPI, QuantinuumAPIOffline, Language

--- a/pytket/extensions/quantinuum/backends/__init__.py
+++ b/pytket/extensions/quantinuum/backends/__init__.py
@@ -15,5 +15,5 @@
 """Backends for processing pytket circuits with Quantinuum devices
 """
 
-from .quantinuum import QuantinuumBackend
+from .quantinuum import QuantinuumBackend, Language
 from .api_wrappers import QuantinuumAPI, QuantinuumAPIOffline

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -25,6 +25,7 @@ import warnings
 import numpy as np
 import requests
 
+from pytket_qir.converter import circuit_to_qir
 from pytket.backends import Backend, ResultHandle, CircuitStatus, StatusEnum
 from pytket.backends.backend import KwargTypes
 from pytket.backends.resulthandle import _ResultIdTuple
@@ -66,8 +67,6 @@ from pytket.wasm import WasmFileHandler
 from pytket.extensions.quantinuum.backends.credential_storage import (
     MemoryCredentialStorage,
 )
-
-from pytket_qir.converter import circuit_to_qir
 
 from .api_wrappers import QuantinuumAPIError, QuantinuumAPI
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -608,7 +608,7 @@ class QuantinuumBackend(Backend):
 
         no_opt = cast(bool, kwargs.get("no_opt", False))
 
-        language = kwargs.get("language", Language.QASM)
+        language = cast(Language, kwargs.get("language", Language.QASM))
 
         handle_list = []
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -35,7 +35,11 @@ from pytket.backends.backend_exceptions import CircuitNotRunError
 from pytket.circuit import Circuit, OpType, Bit  # type: ignore
 from pytket._tket.circuit import _TEMP_BIT_NAME  # type: ignore
 from pytket.extensions.quantinuum._metadata import __extension_version__
-from pytket.extensions.qir import pytket_to_qir
+
+try:
+    from pytket.extensions.qir import pytket_to_qir
+except:
+    pass
 from pytket.qasm import circuit_to_qasm_str
 from pytket.passes import (  # type: ignore
     BasePass,
@@ -630,6 +634,11 @@ class QuantinuumBackend(Backend):
                 warnings.warn(
                     "Support for Language.QIR is experimental; this will probably fail!"
                 )
+                if "pytket_to_qir" not in locals():
+                    raise RuntimeError(
+                        "You must install the `pytket-qir` package in order to use QIR "
+                        "submission."
+                    )
                 # TODO `pytket_to_qir()` returns a string, but we want the bitcode as
                 # bytes. For the moment, just encode the string to bytes to make the
                 # type correct at least. We don't expect this to work yet, hence the

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -25,7 +25,6 @@ import warnings
 import numpy as np
 import requests
 
-from pytket_qir.converter import circuit_to_qir
 from pytket.backends import Backend, ResultHandle, CircuitStatus, StatusEnum
 from pytket.backends.backend import KwargTypes
 from pytket.backends.resulthandle import _ResultIdTuple
@@ -36,6 +35,7 @@ from pytket.backends.backend_exceptions import CircuitNotRunError
 from pytket.circuit import Circuit, OpType, Bit  # type: ignore
 from pytket._tket.circuit import _TEMP_BIT_NAME  # type: ignore
 from pytket.extensions.quantinuum._metadata import __extension_version__
+from pytket.extensions.qir import pytket_to_qir
 from pytket.qasm import circuit_to_qasm_str
 from pytket.passes import (  # type: ignore
     BasePass,
@@ -630,7 +630,13 @@ class QuantinuumBackend(Backend):
                 warnings.warn(
                     "Support for Language.QIR is experimental; this will probably fail!"
                 )
-                quantinuum_circ = b64encode(circuit_to_qir(c0)).decode("utf-8")
+                # TODO `pytket_to_qir()` returns a string, but we want the bitcode as
+                # bytes. For the moment, just encode the string to bytes to make the
+                # type correct at least. We don't expect this to work yet, hence the
+                # warning above.
+                quantinuum_circ = b64encode(pytket_to_qir(c0).encode("utf-8")).decode(
+                    "utf-8"
+                )
 
             if self._MACHINE_DEBUG:
                 handle_list.append(

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket ~= 1.15",
-        "pytket-qir ~= 0.1.5",
+        "pytket-qir == 0.2.0rc1",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket ~= 1.15",
+        "pytket-qir ~= 0.1.5",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket ~= 1.15",
-        "pytket-qir == 0.2.0rc1",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",

--- a/tests/api1_test.py
+++ b/tests/api1_test.py
@@ -27,7 +27,7 @@ from requests_mock.mocker import Mocker
 
 from pytket.backends import ResultHandle, StatusEnum
 from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
-from pytket.extensions.quantinuum.backends import QuantinuumBackend
+from pytket.extensions.quantinuum.backends import QuantinuumBackend, Language
 from pytket.circuit import Circuit  # type: ignore
 from pytket.architecture import FullyConnected  # type: ignore
 from pytket.extensions.quantinuum.backends.quantinuum import (
@@ -503,7 +503,7 @@ def test_submit_qasm_api(
     OPENQASM 2.0;
     include "hqslib1.inc";
     """
-    h1 = backend.submit_qasm(qasm, n_shots=10)
+    h1 = backend.submit_program(Language.QASM, qasm, n_shots=10)
 
     assert h1[0] == fake_job_id
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -24,7 +24,7 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis.strategies._internal import SearchStrategy
 from hypothesis import HealthCheck
-from llvmlite.binding import create_context, parse_assembly
+from llvmlite.binding import create_context, parse_assembly  # type: ignore
 from pytket.backends import CircuitNotValidError
 from pytket.passes import (  # type: ignore
     SequencePass,
@@ -893,6 +893,6 @@ def test_qir_conversion(authenticated_quum_backend: QuantinuumBackend) -> None:
     c0 = Circuit(2).H(0).CX(0, 1).measure_all()
     b = authenticated_quum_backend
     c = b.get_compiled_circuit(c0)
-    h = b.process_circuit(c, n_shots=10, language=Language.QIR)
+    h = b.process_circuit(c, n_shots=10, language=Language.QIR)  # type: ignore
     r = b.get_result(h)
     assert len(r.get_shots()) == 10

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-timeout ~= 1.4.2
 hypothesis
 requests_mock
+llvmlite ~= 0.40.0

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -3,3 +3,4 @@ pytest-timeout ~= 1.4.2
 hypothesis
 requests_mock
 llvmlite ~= 0.40.0
+pytket-qir == 0.2.0rc1


### PR DESCRIPTION
For "experimental" read "not working". However, at least `QuantinuumBackend.submit_program()` with valid QIR bitcode _is_ working, and the plumbing is there for `process_circuits()` (though if you try to use it now you'll get a warning and the submission will almost certainly fail).