### PR TITLE
Change warning message

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -38,6 +38,7 @@ from pytket.extensions.quantinuum._metadata import __extension_version__
 
 try:
     from pytket.qir import pytket_to_qir
+    from pytket.qir import __extension_version__ as pytket_qir_version
 except:
     pass
 from pytket.qasm import circuit_to_qasm_str
@@ -635,6 +636,16 @@ class QuantinuumBackend(Backend):
                     "Support for Language.QIR is experimental; this may fail!"
                 )
                 try:
+                    pytket_qir_version_components = map(
+                        int, pytket_qir_version.split(".")[:2]
+                    )
+                    if (
+                        pytket_qir_version_components[0] == 0
+                        and pytket_qir_version_components[1] < 2
+                    ):
+                        raise RuntimeError(
+                            "Please install `pytket-qir` version 0.2 or above."
+                        )
                     quantinuum_circ = b64encode(pytket_to_qir(c0)).decode("utf-8")  # type: ignore
                 except NameError:
                     raise RuntimeError(

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -634,12 +634,13 @@ class QuantinuumBackend(Backend):
                 warnings.warn(
                     "Support for Language.QIR is experimental; this may fail!"
                 )
-                if "pytket_to_qir" not in locals():
+                try:
+                    quantinuum_circ = b64encode(pytket_to_qir(c0)).decode("utf-8")  # type: ignore
+                except NameError:
                     raise RuntimeError(
                         "You must install the `pytket-qir` package in order to use QIR "
                         "submission."
                     )
-                quantinuum_circ = b64encode(pytket_to_qir(c0)).decode("utf-8")  # type: ignore
 
             if self._MACHINE_DEBUG:
                 handle_list.append(

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -632,15 +632,13 @@ class QuantinuumBackend(Backend):
             else:
                 assert language == Language.QIR
                 warnings.warn(
-                    "Support for Language.QIR is experimental; this will probably fail!"
+                    "Support for Language.QIR is experimental; this may fail!"
                 )
                 if "pytket_to_qir" not in locals():
                     raise RuntimeError(
                         "You must install the `pytket-qir` package in order to use QIR "
                         "submission."
                     )
-                # TODO We don't expect this to work yet, hence the
-                # warning above.
                 quantinuum_circ = b64encode(pytket_to_qir(c0)).decode("utf-8")  # type: ignore
 
             if self._MACHINE_DEBUG:

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -636,8 +636,8 @@ class QuantinuumBackend(Backend):
                     "Support for Language.QIR is experimental; this may fail!"
                 )
                 try:
-                    pytket_qir_version_components = map(
-                        int, pytket_qir_version.split(".")[:2]
+                    pytket_qir_version_components = list(
+                        map(int, pytket_qir_version.split(".")[:2])
                     )
                     if (
                         pytket_qir_version_components[0] == 0

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -884,6 +884,7 @@ attributes #0 = { "EntryPoint" "maxQubitIndex"="1" "maxResultIndex"="1" "require
     assert len(r.get_shots()) == 10
 
 
+@pytest.mark.skip(reason="`Language.QIR` not yet working with `process_circuit()`")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
     "authenticated_quum_backend", [{"device_name": "H1-1SC"}], indirect=True

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -884,7 +884,6 @@ attributes #0 = { "EntryPoint" "maxQubitIndex"="1" "maxResultIndex"="1" "require
     assert len(r.get_shots()) == 10
 
 
-@pytest.mark.skip(reason="`Language.QIR` not yet working with `process_circuit()`")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
     "authenticated_quum_backend", [{"device_name": "H1-1SC"}], indirect=True


### PR DESCRIPTION
Test fails with:

```
self = <pytket.qir.conversion.conversion.QirGenerator object at 0x7fc3ec940c70>, command = PhasedX(3.5, 0.5) node[0];

    def _rebase_command_to_gateset(self, command: Command) -> Optional[Circuit]:
        """Rebase to the target gateset if needed."""
        optype = command.op.type
        params = command.op.params
        args = command.args
        if optype not in self.module.gateset.base_gateset:
            circuit = Circuit(self.circuit.n_qubits, self.circuit.n_bits)
>           circuit.add_gate(optype, params, args)
E           RuntimeError: Circuit does not contain unit with id: node[0]

../env/lib/python3.10/site-packages/pytket/qir/conversion/conversion.py:292: RuntimeError
```