### PR TITLE
Truncate results from QIR processing to desired width

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -448,9 +448,10 @@ class QuantinuumBackend(Backend):
 
     @property
     def _result_id_type(self) -> _ResultIdTuple:
-        return tuple((str, str))
+        return tuple((str, str, int))
 
-    def get_jobid(self, handle: ResultHandle) -> str:
+    @staticmethod
+    def get_jobid(handle: ResultHandle) -> str:
         """Return the corresponding Quantinuum Job ID from a ResultHandle.
 
         :param handle: result handle.
@@ -459,6 +460,30 @@ class QuantinuumBackend(Backend):
         :rtype: str
         """
         return cast(str, handle[0])
+
+    @staticmethod
+    def get_ppcirc_rep(handle: ResultHandle) -> Any:
+        """Return the JSON serialization of the classiocal postprocessing circuit
+        attached to a handle, if any.
+
+        :param handle: result handle
+        :return: serialized post-processing circuit, if any
+        """
+        return json.loads(cast(str, handle[1]))
+
+    @staticmethod
+    def get_results_width(handle: ResultHandle) -> Optional[int]:
+        """Return the truncation width of the results, if any.
+
+        :param handle: result handle
+        :return: truncation width of results, if any
+        """
+        n = cast(int, handle[2])
+        if n == -1:
+            return None
+        else:
+            assert n >= 0
+            return n
 
     def submit_program(
         self,
@@ -473,6 +498,7 @@ class QuantinuumBackend(Backend):
         no_opt: bool = False,
         options: Optional[Dict[str, Any]] = None,
         request_options: Optional[Dict[str, Any]] = None,
+        results_width: Optional[int] = None,
     ) -> ResultHandle:
         """Submit a program directly to the backend.
 
@@ -503,6 +529,9 @@ class QuantinuumBackend(Backend):
         :param request_options: Extra options to add to the request body as a
           json-style dictionary, defaults to None
         :type request_options: Optional[Dict[str, Any]], optional
+        :param results_width: Number of bits to retain in returned results (if unset,
+            retain all)
+        :type results_width: Optional[int]
         :raises WasmUnsupported: WASM submitted to backend that does not support it.
         :raises QuantinuumAPIError: API error.
         :raises ConnectionError: Connection to remote API failed
@@ -544,6 +573,8 @@ class QuantinuumBackend(Backend):
         # apply any overrides or extra options
         body.update(request_options or {})
 
+        n_bits: int = -1 if results_width is None else results_width
+
         try:
             res = self.api_handler._submit_job(body)
             if self.api_handler.online:
@@ -553,14 +584,14 @@ class QuantinuumBackend(Backend):
                         f'HTTP error submitting job, {jobdict["error"]}'
                     )
             else:
-                return ResultHandle(cast(str, ""), "null")
+                return ResultHandle(cast(str, ""), "null", n_bits)
         except ConnectionError:
             raise ConnectionError(
                 f"{self._label} Connection Error: Error during submit..."
             )
 
         # extract job ID from response
-        return ResultHandle(cast(str, jobdict["job"]), "null")
+        return ResultHandle(cast(str, jobdict["job"]), "null", n_bits)
 
     def process_circuits(
         self,
@@ -628,6 +659,7 @@ class QuantinuumBackend(Backend):
                 ppcirc_rep = ppcirc.to_dict()
             else:
                 c0, ppcirc_rep = circ, None
+            n_bits = c0.n_bits
             if language == Language.QASM:
                 quantinuum_circ = circuit_to_qasm_str(c0, header="hqslib1")
             else:
@@ -668,6 +700,7 @@ class QuantinuumBackend(Backend):
                     ResultHandle(
                         _DEBUG_HANDLE_PREFIX + str((circ.n_qubits, n_shots)),
                         json.dumps(ppcirc_rep),
+                        n_bits,
                     )
                 )
             else:
@@ -687,7 +720,9 @@ class QuantinuumBackend(Backend):
                     ),
                 )
 
-                handle = ResultHandle(handle[0], json.dumps(ppcirc_rep))
+                handle = ResultHandle(
+                    self.get_jobid(handle), json.dumps(ppcirc_rep), n_bits
+                )
                 handle_list.append(handle)
                 self._cache[handle] = dict()
 
@@ -721,14 +756,12 @@ class QuantinuumBackend(Backend):
         self._check_batchable()
 
         kwargs["request_options"] = {"batch-exec": max_batch_cost}
-        [
-            h1,
-        ] = self.process_circuits([circuit], n_shots, valid_check, **kwargs)
+        [h1] = self.process_circuits([circuit], n_shots, valid_check, **kwargs)
 
         # make sure the starting job is received, such that subsequent addtions
         # to batch will be recognised as being added to an existing batch
         self.api_handler.retrieve_job_status(
-            str(h1[0]),
+            self.get_jobid(h1),
             use_websocket=cast(bool, kwargs.get("use_websocket", True)),
         )
         return h1
@@ -787,7 +820,7 @@ class QuantinuumBackend(Backend):
 
     def cancel(self, handle: ResultHandle) -> None:
         if self.api_handler is not None:
-            jobid = str(handle[0])
+            jobid = self.get_jobid(handle)
             self.api_handler.cancel(jobid)
 
     def _update_cache_result(self, handle: ResultHandle, res: BackendResult) -> None:
@@ -802,7 +835,7 @@ class QuantinuumBackend(Backend):
         self, handle: ResultHandle, **kwargs: KwargTypes
     ) -> CircuitStatus:
         self._check_handle_type(handle)
-        jobid = str(handle[0])
+        jobid = self.get_jobid(handle)
         if self._MACHINE_DEBUG or jobid.startswith(_DEBUG_HANDLE_PREFIX):
             return CircuitStatus(StatusEnum.COMPLETED)
         use_websocket = cast(bool, kwargs.get("use_websocket", True))
@@ -822,12 +855,13 @@ class QuantinuumBackend(Backend):
         circ_status = _parse_status(response)
         if circ_status.status is StatusEnum.COMPLETED:
             if "results" in response:
-                ppcirc_rep = json.loads(cast(str, handle[1]))
+                ppcirc_rep = self.get_ppcirc_rep(handle)
+                n_bits = self.get_results_width(handle)
                 ppcirc = (
                     Circuit.from_dict(ppcirc_rep) if ppcirc_rep is not None else None
                 )
                 self._update_cache_result(
-                    handle, _convert_result(response["results"], ppcirc)
+                    handle, _convert_result(response["results"], ppcirc, n_bits)
                 )
         return circ_status
 
@@ -844,7 +878,7 @@ class QuantinuumBackend(Backend):
             If no results are available, the first element is None.
         :rtype: Tuple[Optional[BackendResult], CircuitStatus]
         """
-        job_id = str(handle[0])
+        job_id = self.get_jobid(handle)
         jr = self.api_handler.retrieve_job_status(job_id)
         if not jr:
             raise QuantinuumAPIError(f"Unable to retrive job {job_id}")
@@ -852,9 +886,10 @@ class QuantinuumBackend(Backend):
         circ_status = _parse_status(jr)
         if res is None:
             return None, circ_status
-        ppcirc_rep = json.loads(cast(str, handle[1]))
+        ppcirc_rep = self.get_ppcirc_rep(handle)
         ppcirc = Circuit.from_dict(ppcirc_rep) if ppcirc_rep is not None else None
-        backres = _convert_result(res, ppcirc)
+        n_bits = self.get_results_width(handle)
+        backres = _convert_result(res, ppcirc, n_bits)
         return backres, circ_status
 
     def get_result(self, handle: ResultHandle, **kwargs: KwargTypes) -> BackendResult:
@@ -865,14 +900,18 @@ class QuantinuumBackend(Backend):
         try:
             return super().get_result(handle)
         except CircuitNotRunError:
-            jobid = str(handle[0])
-            ppcirc_rep = json.loads(cast(str, handle[1]))
+            jobid = self.get_jobid(handle)
+            ppcirc_rep = self.get_ppcirc_rep(handle)
+            n_bits = self.get_results_width(handle)
+
             ppcirc = Circuit.from_dict(ppcirc_rep) if ppcirc_rep is not None else None
 
             if self._MACHINE_DEBUG or jobid.startswith(_DEBUG_HANDLE_PREFIX):
                 debug_handle_info = jobid[len(_DEBUG_HANDLE_PREFIX) :]
                 n_qubits, shots = literal_eval(debug_handle_info)
-                return _convert_result({"c": (["0" * n_qubits] * shots)}, ppcirc)
+                return _convert_result(
+                    {"c": (["0" * n_qubits] * shots)}, ppcirc, n_bits
+                )
             # TODO exception handling when jobid not found on backend
             timeout = kwargs.get("timeout")
             if timeout is not None:
@@ -893,7 +932,7 @@ class QuantinuumBackend(Backend):
             except KeyError:
                 raise GetResultFailed("Results missing in device return data.")
 
-            backres = _convert_result(res, ppcirc)
+            backres = _convert_result(res, ppcirc, n_bits)
             self._update_cache_result(handle, backres)
             return backres
 
@@ -995,7 +1034,9 @@ _xcirc.add_phase(0.5)
 
 
 def _convert_result(
-    resultdict: Dict[str, List[str]], ppcirc: Optional[Circuit] = None
+    resultdict: Dict[str, List[str]],
+    ppcirc: Optional[Circuit] = None,
+    n_bits: Optional[int] = None,
 ) -> BackendResult:
     array_dict = {
         creg: np.array([list(a) for a in reslist]).astype(np.uint8)
@@ -1007,6 +1048,11 @@ def _convert_result(
         for name in reversed_creg_names
         for ind in range(array_dict[name].shape[-1] - 1, -1, -1)
     ]
+    if n_bits is not None:
+        assert n_bits >= 0 and n_bits <= len(c_bits)
+        c_bits = c_bits[:n_bits]
+        for creg in array_dict.keys():
+            array_dict[creg] = array_dict[creg][:, :n_bits]
 
     stacked_array = np.hstack([array_dict[name] for name in reversed_creg_names])
     return BackendResult(

--- a/tests/api1_test.py
+++ b/tests/api1_test.py
@@ -540,12 +540,12 @@ def test_get_partial_result(
         headers={"Content-Type": "application/json"},
     )
     backend = QuantinuumBackend(device_name="H1-2SC", api_handler=mock_quum_api_handler)
-    h1 = ResultHandle(queued_job_id, "null")
+    h1 = ResultHandle(queued_job_id, "null", -1)
     res, status = backend.get_partial_result(h1)
     assert res is None
     assert status.status == StatusEnum.QUEUED
 
-    h2 = ResultHandle(running_job_id, "null")
+    h2 = ResultHandle(running_job_id, "null", -1)
     res, status = backend.get_partial_result(h2)
     assert res is not None
     assert status.status == StatusEnum.RUNNING

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -928,4 +928,6 @@ def test_qir_conversion(authenticated_quum_backend: QuantinuumBackend) -> None:
     c = b.get_compiled_circuit(c0)
     h = b.process_circuit(c, n_shots=10, language=Language.QIR)  # type: ignore
     r = b.get_result(h)
-    assert len(r.get_shots()) == 10
+    shots = r.get_shots()
+    assert len(shots) == 10
+    assert all(len(shot) == 2 for shot in shots)


### PR DESCRIPTION
Add an extra field to the `ResultHandle` to track this. While here, make extraction of values from result handles a little less error-prone by adding and using dedicated methods.