### PR TITLE
Typo when testing for the INTEGRATION flag

### DIFF
--- a/.github/workflows/build-test
+++ b/.github/workflows/build-test
@@ -65,7 +65,7 @@ python -m pip install --upgrade --pre pytket~=1.0
 pytest --doctest-modules unit/
 
 # integration tests are run if specified
-if  [[ -z "${INTEGRATION}" ]]
+if  [[ ! -z "${INTEGRATION}" ]]
 then
     pytest --doctest-modules integration/
 fi


### PR DESCRIPTION
Fix a typo in the `build-test` script when checking whether to run or not the integration tests.