### PR TITLE
Store FullyConnected("q") in BackendInfo

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.19.0
+-----------------
+* Update `FullyConnected` Architecture to label Node with "q", matching
+  compilation by `FlattenRelabelRegistersPass`.
+
 0.18.0 (July 2023)
 ------------------
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -288,7 +288,7 @@ class QuantinuumBackend(Backend):
             name=cls.__name__,
             device_name=name,
             version=__extension_version__,
-            architecture=FullyConnected(n_qubits, "node"),
+            architecture=FullyConnected(n_qubits, "q"),
             gate_set=_get_gateset(gate_set),
             n_cl_reg=n_cl_reg,
             supports_fast_feedforward=True,

--- a/tests/unit/api1_test.py
+++ b/tests/unit/api1_test.py
@@ -447,9 +447,7 @@ def test_available_devices(
     backinfo = devices[0]
 
     assert backinfo.device_name == mock_machine_info["name"]
-    assert backinfo.architecture == FullyConnected(
-        mock_machine_info["n_qubits"], "q"
-    )
+    assert backinfo.architecture == FullyConnected(mock_machine_info["n_qubits"], "q")
     assert backinfo.version == __extension_version__
     assert backinfo.supports_fast_feedforward == True
     assert backinfo.supports_midcircuit_measurement == True

--- a/tests/unit/api1_test.py
+++ b/tests/unit/api1_test.py
@@ -448,7 +448,7 @@ def test_available_devices(
 
     assert backinfo.device_name == mock_machine_info["name"]
     assert backinfo.architecture == FullyConnected(
-        mock_machine_info["n_qubits"], "node"
+        mock_machine_info["n_qubits"], "q"
     )
     assert backinfo.version == __extension_version__
     assert backinfo.supports_fast_feedforward == True


### PR DESCRIPTION
Currently the held architecture labels UnitID with "node".
However, the `FlattenRelabelRegistersPass` relabels all Circuit qubit to label "q".
This PR corrects this mismatch.