### PR TITLE
Update optimisation level 0 to add implicit swap gates

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -399,7 +399,14 @@ class QuantinuumBackend(Backend):
         # https://cqcl.github.io/pytket-quantinuum/api/index.html#default-compilation
         # Edit this docs source file -> pytket-quantinuum/docs/intro.txt
         if optimisation_level == 0:
-            passlist.append(self.rebase_pass())
+            passlist.extend(
+                [
+                auto_rebase_pass({OpType.Rz, OpType.PhasedX, OpType.TK2}),
+                NormaliseTK2(),
+                DecomposeTK2(),
+                self.rebase_pass(),
+                ]
+            )
         elif optimisation_level == 1:
             passlist.extend(
                 [

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -408,7 +408,14 @@ class QuantinuumBackend(Backend):
             passlist.extend(
                 [
                     CustomPass(lambda c: replace_swaps(c)),
-                    auto_rebase_pass({OpType.Rz, OpType.PhasedX, OpType.TK2}),
+                    auto_rebase_pass(
+                        {
+                            OpType.Rz,
+                            OpType.PhasedX,
+                            OpType.TK2,
+                            OpType.ZZMax,
+                        }
+                    ),
                     NormaliseTK2(),
                     DecomposeTK2(),
                     self.rebase_pass(),

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -398,9 +398,16 @@ class QuantinuumBackend(Backend):
         # then please update this page accordingly
         # https://cqcl.github.io/pytket-quantinuum/api/index.html#default-compilation
         # Edit this docs source file -> pytket-quantinuum/docs/intro.txt
+
         if optimisation_level == 0:
+
+            def replace_swaps(c: Circuit) -> Circuit:
+                c.replace_SWAPs()
+                return c
+
             passlist.extend(
                 [
+                    CustomPass(lambda c: replace_swaps(c)),
                     auto_rebase_pass({OpType.Rz, OpType.PhasedX, OpType.TK2}),
                     NormaliseTK2(),
                     DecomposeTK2(),

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -401,10 +401,10 @@ class QuantinuumBackend(Backend):
         if optimisation_level == 0:
             passlist.extend(
                 [
-                auto_rebase_pass({OpType.Rz, OpType.PhasedX, OpType.TK2}),
-                NormaliseTK2(),
-                DecomposeTK2(),
-                self.rebase_pass(),
+                    auto_rebase_pass({OpType.Rz, OpType.PhasedX, OpType.TK2}),
+                    NormaliseTK2(),
+                    DecomposeTK2(),
+                    self.rebase_pass(),
                 ]
             )
         elif optimisation_level == 1:

--- a/tests/unit/convert_test.py
+++ b/tests/unit/convert_test.py
@@ -121,3 +121,51 @@ def test_resize_scratch_registers() -> None:
     c_compiled = circ.copy()
     scratch_reg_resize_pass(10).apply(c_compiled)
     assert circ == c_compiled
+
+def test_implicit_swap_removal() -> None:
+
+    b = QuantinuumBackend("", machine_debug=True)
+    c = Circuit(2).ISWAPMax(0,1)
+    compiled = b.get_compiled_circuit(c, 0)
+    assert compiled.n_gates_of_type(OpType.ZZMax) == 1
+    assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    c  = Circuit(2).ISWAPMax(0,1)
+    b.rebase_pass().apply(c)
+    assert c.n_gates_of_type(OpType.ZZMax) == 2
+    assert c.n_gates_of_type(OpType.ZZPhase) == 0
+
+    c = Circuit(2).Sycamore(0,1)
+    compiled = b.get_compiled_circuit(c,0)
+    assert compiled.n_gates_of_type(OpType.ZZMax) == 2
+    assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    c = Circuit(2).Sycamore(0,1)
+    b.rebase_pass().apply(c)
+    assert  c.n_gates_of_type(OpType.ZZMax) == 3
+    assert c.n_gates_of_type(OpType.ZZPhase) == 0
+
+    c = Circuit(2).ISWAP(0.3, 0, 1)
+    compiled = b.get_compiled_circuit(c, 0)
+    assert compiled.n_gates_of_type(OpType.ZZMax) == 2 
+    assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    c = Circuit(2).ISWAP(0.3,0,1)
+    b.rebase_pass().apply(c)
+    assert c.n_gates_of_type(OpType.ZZMax) == 2
+    assert c.n_gates_of_type(OpType.ZZPhase) == 0
+
+    c = Circuit(2).ISWAPMax(0,1).ISWAPMax(1,0)
+    compiled = b.get_compiled_circuit(c, 0)
+    assert compiled.n_gates_of_type(OpType.ZZMax) == 2
+    assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    c = Circuit(2).ISWAPMax(0,1).ISWAPMax(1,0)
+    compiled = b.get_compiled_circuit(c, 1)
+    assert compiled.n_gates_of_type(OpType.ZZMax) == 0
+    assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    c = Circuit(2).ISWAPMax(0,1).ISWAPMax(1,0)
+    b.rebase_pass().apply(c)
+    assert c.n_gates_of_type(OpType.ZZMax) == 4
+    assert c.n_gates_of_type(OpType.ZZPhase) == 0
+    
+
+
+if __name__ == "__main__":
+    test_implicit_swap_removal()

--- a/tests/unit/convert_test.py
+++ b/tests/unit/convert_test.py
@@ -122,49 +122,48 @@ def test_resize_scratch_registers() -> None:
     scratch_reg_resize_pass(10).apply(c_compiled)
     assert circ == c_compiled
 
-def test_implicit_swap_removal() -> None:
 
+def test_implicit_swap_removal() -> None:
     b = QuantinuumBackend("", machine_debug=True)
-    c = Circuit(2).ISWAPMax(0,1)
+    c = Circuit(2).ISWAPMax(0, 1)
     compiled = b.get_compiled_circuit(c, 0)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 1
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
-    c  = Circuit(2).ISWAPMax(0,1)
+    c = Circuit(2).ISWAPMax(0, 1)
     b.rebase_pass().apply(c)
     assert c.n_gates_of_type(OpType.ZZMax) == 2
     assert c.n_gates_of_type(OpType.ZZPhase) == 0
 
-    c = Circuit(2).Sycamore(0,1)
-    compiled = b.get_compiled_circuit(c,0)
+    c = Circuit(2).Sycamore(0, 1)
+    compiled = b.get_compiled_circuit(c, 0)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 2
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
-    c = Circuit(2).Sycamore(0,1)
+    c = Circuit(2).Sycamore(0, 1)
     b.rebase_pass().apply(c)
-    assert  c.n_gates_of_type(OpType.ZZMax) == 3
+    assert c.n_gates_of_type(OpType.ZZMax) == 3
     assert c.n_gates_of_type(OpType.ZZPhase) == 0
 
     c = Circuit(2).ISWAP(0.3, 0, 1)
     compiled = b.get_compiled_circuit(c, 0)
-    assert compiled.n_gates_of_type(OpType.ZZMax) == 2 
+    assert compiled.n_gates_of_type(OpType.ZZMax) == 2
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
-    c = Circuit(2).ISWAP(0.3,0,1)
+    c = Circuit(2).ISWAP(0.3, 0, 1)
     b.rebase_pass().apply(c)
     assert c.n_gates_of_type(OpType.ZZMax) == 2
     assert c.n_gates_of_type(OpType.ZZPhase) == 0
 
-    c = Circuit(2).ISWAPMax(0,1).ISWAPMax(1,0)
+    c = Circuit(2).ISWAPMax(0, 1).ISWAPMax(1, 0)
     compiled = b.get_compiled_circuit(c, 0)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 2
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
-    c = Circuit(2).ISWAPMax(0,1).ISWAPMax(1,0)
+    c = Circuit(2).ISWAPMax(0, 1).ISWAPMax(1, 0)
     compiled = b.get_compiled_circuit(c, 1)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 0
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
-    c = Circuit(2).ISWAPMax(0,1).ISWAPMax(1,0)
+    c = Circuit(2).ISWAPMax(0, 1).ISWAPMax(1, 0)
     b.rebase_pass().apply(c)
     assert c.n_gates_of_type(OpType.ZZMax) == 4
     assert c.n_gates_of_type(OpType.ZZPhase) == 0
-    
 
 
 if __name__ == "__main__":

--- a/tests/unit/convert_test.py
+++ b/tests/unit/convert_test.py
@@ -191,6 +191,10 @@ def test_implicit_swap_removal() -> None:
     assert c.n_gates_of_type(OpType.ZZMax) == 3
     assert c.n_gates_of_type(OpType.ZZPhase) == 0
 
+    c = Circuit(2).ZZMax(0, 1)
+    compiled = b.get_compiled_circuit(c, 0)
+    assert compiled.n_gates == 1
+
 
 if __name__ == "__main__":
     test_implicit_swap_removal()

--- a/tests/unit/convert_test.py
+++ b/tests/unit/convert_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from pytket.circuit import Circuit, OpType, reg_eq  # type: ignore
+from pytket.circuit import Circuit, Qubit, OpType, reg_eq  # type: ignore
 from pytket._tket.circuit import _TEMP_BIT_NAME, _TEMP_BIT_REG_BASE  # type: ignore
 from pytket.extensions.quantinuum import QuantinuumBackend
 from pytket.extensions.quantinuum.backends.quantinuum import scratch_reg_resize_pass
@@ -129,6 +129,9 @@ def test_implicit_swap_removal() -> None:
     compiled = b.get_compiled_circuit(c, 0)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 1
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    iqp = compiled.implicit_qubit_permutation()
+    assert iqp[Qubit(0)] == Qubit(1)
+    assert iqp[Qubit(1)] == Qubit(0)
     c = Circuit(2).ISWAPMax(0, 1)
     b.rebase_pass().apply(c)
     assert c.n_gates_of_type(OpType.ZZMax) == 2
@@ -138,6 +141,9 @@ def test_implicit_swap_removal() -> None:
     compiled = b.get_compiled_circuit(c, 0)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 2
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    iqp = compiled.implicit_qubit_permutation()
+    assert iqp[Qubit(0)] == Qubit(1)
+    assert iqp[Qubit(1)] == Qubit(0)
     c = Circuit(2).Sycamore(0, 1)
     b.rebase_pass().apply(c)
     assert c.n_gates_of_type(OpType.ZZMax) == 3
@@ -147,6 +153,9 @@ def test_implicit_swap_removal() -> None:
     compiled = b.get_compiled_circuit(c, 0)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 2
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    iqp = compiled.implicit_qubit_permutation()
+    assert iqp[Qubit(0)] == Qubit(0)
+    assert iqp[Qubit(1)] == Qubit(1)
     c = Circuit(2).ISWAP(0.3, 0, 1)
     b.rebase_pass().apply(c)
     assert c.n_gates_of_type(OpType.ZZMax) == 2
@@ -156,13 +165,30 @@ def test_implicit_swap_removal() -> None:
     compiled = b.get_compiled_circuit(c, 0)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 2
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    iqp = compiled.implicit_qubit_permutation()
+    assert iqp[Qubit(0)] == Qubit(0)
+    assert iqp[Qubit(1)] == Qubit(1)
     c = Circuit(2).ISWAPMax(0, 1).ISWAPMax(1, 0)
     compiled = b.get_compiled_circuit(c, 1)
     assert compiled.n_gates_of_type(OpType.ZZMax) == 0
     assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    iqp = compiled.implicit_qubit_permutation()
+    assert iqp[Qubit(0)] == Qubit(0)
     c = Circuit(2).ISWAPMax(0, 1).ISWAPMax(1, 0)
     b.rebase_pass().apply(c)
     assert c.n_gates_of_type(OpType.ZZMax) == 4
+    assert c.n_gates_of_type(OpType.ZZPhase) == 0
+
+    c = Circuit(2).SWAP(0, 1)
+    compiled = b.get_compiled_circuit(c, 0)
+    assert compiled.n_gates_of_type(OpType.ZZMax) == 0
+    assert compiled.n_gates_of_type(OpType.ZZPhase) == 0
+    iqp = compiled.implicit_qubit_permutation()
+    assert iqp[Qubit(0)] == Qubit(1)
+    assert iqp[Qubit(1)] == Qubit(0)
+    c = Circuit(2).SWAP(0, 1)
+    b.rebase_pass().apply(c)
+    assert c.n_gates_of_type(OpType.ZZMax) == 3
     assert c.n_gates_of_type(OpType.ZZPhase) == 0
 
 


### PR DESCRIPTION
This PR is one way of satisfying https://github.com/CQCL/pytket-quantinuum/issues/181.

Some operations, such as `OpType.SWAP`, `OpType.ISWAPMax` and `OpType.Sycamore` have the effect of performing a wire swap in a Circuit. Given this they can be decompose in different ways, either correcting for the wire swap with operations or allowing it to be performed "implicitly" by rewriting the DAG.

We would like optimisation level 0 to allow implicit swaps when compiling circuits, but not perform any further optimisation.

Optimisation levels 1 and 2 allow implicit wire swaps already: they resynthesise all two-qubit gates into TK2, merge them and then Decompose them into the allowed primitives (here ZZMax) with `allow_swaps = True`. In this way they produced optimised circuits with implicit wire swaps.

Optimisation level 0 does not do this, only performing a rebase of the Circuit into {Rz, PhasedX, ZZMax}.

Note that a rebase pass works as follows:
1) Convert all gates to TK1 or TK2 without optimisation
2) Convert TK1 and TK2 gates to desired gate set via pre-defined Circuit definitions

Therefore we can emulate rebasing with implicit wire swaps without optimisation by the given compiler passes:
1) rebase the Circuit to {Rz, PhasedX, TK2} (does not merge or optimise TK2 gates)
2) NormaliseTK2() (a Compiler Pass precondition, should not effect TK2 produced from ISWAPMax, Sycamore or SWAP given how they are converted to TK2)
3) DecomposeTK2(), with `allow_swaps` = True, adding implicit swap rewiring
4) The usual rebase_pass, compiling to {Rz, PhasedX, ZZMax}
