### PR TITLE
add leakage gadget functions to docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,3 +7,6 @@ API documentation
 
 .. automodule:: pytket.extensions.quantinuum.backends.config
     :members:
+
+.. automodule:: pytket.extensions.quantinuum.backends.leakage_gadget
+    :members:


### PR DESCRIPTION
Adding some functions for leakage gadgets to the API docs


![Screenshot 2023-09-25 at 14 04 28](https://github.com/CQCL/pytket-quantinuum/assets/93673602/21fe8cc8-17dc-43de-9eb4-d5909a252ca6)
