### PR TITLE
Set default two-qubit gate when compilation config is provided without one

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Unreleased
 
 * Don't include ``SimplifyInitial`` in default passes; instead make it an option
   to ``process_circuits()``.
+* Fix: set default two-qubit gate when compilation config is provided without
+  specifying one.
 
 0.23.0 (September 2023)
 -----------------------

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -290,6 +290,8 @@ class QuantinuumBackend(Backend):
             )
         else:
             self.compilation_config = compilation_config
+            if self.compilation_config.target_2qb_gate is None:
+                self.compilation_config.target_2qb_gate = self._default_2q_gate
 
     def get_compilation_config(self) -> QuantinuumBackendCompilationConfig:
         """Get the current compilation configuration."""


### PR DESCRIPTION
Fixes #250 .