### PR TITLE
Allow MemoryCredentialStorage to access cached username

### DIFF
--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -24,7 +24,7 @@ import json
 import getpass
 from requests import Session
 from requests.models import Response
-from websockets import connect, exceptions  # type: ignore
+from websockets import connect, exceptions
 import nest_asyncio  # type: ignore
 
 from .config import QuantinuumConfig


### PR DESCRIPTION
#247 slightly changes the default behaviour of `QuantinuumBackend`, namely the default `api_handler`, which uses `MemoryCredentialStorage` for storing credentials, won't use the cached login email address even if the user did cache their email using `set_quantinuum_config`. This means email will always be asked if default `api_handler` is used. I suspect that many users won't like this change.

The intent of this PR is to temporarily revert this behaviour change until we agree on what the default behaviour should be.