### PR TITLE
Add an extra `RemoveRedundancies` pass for levels 1 and 2.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Unreleased
 
 * Add ``QuantinuumConfigCredentialStorage`` for caching API tokens in local pytket
   configuration file.
+* Add an additonal ``RemoveRedundancies`` pass to the default passes for levels 1 and 2 to remove Rz gates before measurement.
 
 0.25.0 (October 2023)
 ---------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -94,6 +94,9 @@ The passes applied by different levels of optimisation are specified in the tabl
      - `FlattenRelabelRegistersPass <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.FlattenRelabelRegistersPass>`_
    * -
      - `FlattenRelabelRegistersPass <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.FlattenRelabelRegistersPass>`_
+     - `RemoveRedundancies <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.RemoveRedundancies>`_
+   * -
+     - `RemoveRedundancies <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.RemoveRedundancies>`_
      -
 
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -494,6 +494,7 @@ class QuantinuumBackend(Backend):
                     ZZPhaseToRz(),
                     RemoveRedundancies(),
                     squash,
+                    RemoveRedundancies(),
                 ]
             )
         else:
@@ -505,6 +506,7 @@ class QuantinuumBackend(Backend):
                     self.rebase_pass(),
                     RemoveRedundancies(),
                     squash,
+                    RemoveRedundancies(),
                 ]
             )
         # In TKET, a qubit register with N qubits can have qubits

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -1199,7 +1199,8 @@ def test_default_2q_gate(authenticated_quum_handler: QuantinuumAPI) -> None:
 # https://github.com/CQCL/pytket-quantinuum/issues/265
 def test_Rz_removal_before_measurements() -> None:
     backend = QuantinuumBackend("H1-1E", machine_debug=True)
-    # Circuit will contain an Rz gate if RemoveRedundancies isn't applied after SquashRzPhasedX
+    # Circuit will contain an Rz gate if RemoveRedundancies
+    #  isn't applied after SquashRzPhasedX
     circuit = Circuit(2).H(0).Rz(0.75, 0).CX(0, 1).measure_all()
 
     for optimisation_level in (1, 2):


### PR DESCRIPTION
Added an extra `RemoveRedundancies` pass to levels 1 and 2 in the default passes to get rid of Rz gates before measurement.

closes https://github.com/CQCL/pytket-quantinuum/issues/265.