### PR TITLE
Remove redundant type declarations from docstrings

### DIFF
--- a/.github/workflows/docs/conf.py
+++ b/.github/workflows/docs/conf.py
@@ -38,10 +38,10 @@ html_css_files = ["custom.css"]
 pytketdoc_base = "https://tket.quantinuum.com/api-docs/"
 
 intersphinx_mapping = {
-    "https://docs.python.org/3/": None,
-    pytketdoc_base: None,
-    "https://qiskit.org/documentation/": None,
-    "http://docs.qulacs.org/en/latest/": None,
+    "python": ("https://docs.python.org/3/", None),
+    "pytket": (pytketdoc_base, None),
+    "qiskit": ("https://qiskit.org/documentation/", None),
+    "qulacs": ("http://docs.qulacs.org/en/latest/", None),
 }
 
 autodoc_member_order = "groupwise"

--- a/.github/workflows/docs/requirements.txt
+++ b/.github/workflows/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx == 6.2.1
+sphinx ~= 6.2
 sphinx_book_theme >= 1.0.1, <2.0
 sphinx-autodoc-typehints
 sphinx-copybutton

--- a/.github/workflows/docs/requirements.txt
+++ b/.github/workflows/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 4.3.2, <6.2.0
+sphinx == 6.2.1
 sphinx_book_theme >= 1.0.1, <2.0
 sphinx-copybutton
 enum-tools[sphinx]

--- a/.github/workflows/docs/requirements.txt
+++ b/.github/workflows/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx == 6.2.1
 sphinx_book_theme >= 1.0.1, <2.0
+sphinx-autodoc-typehints
 sphinx-copybutton
 enum-tools[sphinx]

--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -562,15 +562,13 @@ class QuantinuumAPIOffline:
         return self.machine_list
 
     def full_login(self) -> None:
-        """No login offline with the offline API
-        :return: None"""
+        """No login offline with the offline API"""
 
         return None
 
     def login(self) -> str:
         """No login offline with the offline API, this function will always
-        return an empty api token
-        :return: empty api token"""
+        return an empty api token"""
         return ""
 
     def _submit_job(self, body: Dict) -> None:

--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -99,20 +99,14 @@ class QuantinuumAPI:
         :param token_store: JWT Token store, defaults to None
             A new MemoryCredentialStorage will be initialised
             if None is provided.
-        :type token_store: CredentialStorage, optional
         :param api_url: _description_, defaults to DEFAULT_API_URL
-        :type api_url: Optional[str], optional
         :param api_version: API version, defaults to 1
-        :type api_version: int, optional
         :param use_websocket: Whether to use websocket to retrieve, defaults to True
-        :type use_websocket: bool, optional
         :param support_mfa: Whether to wait for the user to input the auth code,
             defaults to True
-        :type support_mfa: bool, optional
         :param session: Session for HTTP requests, defaults to None
             A new requests.Session will be initialised if None
             is provided
-        :type session: requests.Session, optional
         """
         self.online = True
 
@@ -341,9 +335,7 @@ class QuantinuumAPI:
         Retrieves job status from device.
 
         :param job_id: unique id of job
-        :type job_id: str
         :param use_websocket: use websocket to minimize interaction
-        :type use_websocket: bool
 
         :return: (dict) output from API
 
@@ -370,9 +362,7 @@ class QuantinuumAPI:
         Retrieves job from device.
 
         :param job_id: unique id of job
-        :type job_id: str
         :param use_websocket: use websocket to minimize interaction
-        :type use_websocket: bool
 
         :return: (dict) output from API
 
@@ -471,7 +461,6 @@ class QuantinuumAPI:
         Check status of machine.
 
         :param machine: machine name
-        :type machine: str
 
         :return: (str) status of machine
 
@@ -491,7 +480,6 @@ class QuantinuumAPI:
         Cancels job.
 
         :param job_id: job ID to cancel
-        :type job_id: str
 
         :return: (dict) output from API
 
@@ -531,7 +519,6 @@ class QuantinuumAPIOffline:
             "n_shots": 10000,
             "batching": True,
             }
-        :type machine_list: list
         """
         if machine_list == None:
             machine_list = [
@@ -590,7 +577,6 @@ class QuantinuumAPIOffline:
         """The function will take the submitted job and store it for later
 
         :param body: submitted job
-        :type body: dict
 
         :return: None
         """

--- a/pytket/extensions/quantinuum/backends/leakage_gadget.py
+++ b/pytket/extensions/quantinuum/backends/leakage_gadget.py
@@ -31,13 +31,9 @@ def get_leakage_gadget_circuit(
 
     :param circuit_qubit: Generated circuit detects whether leakage errors
         have occurred in this qubit.
-    :type circuit_qubit: Qubit
     :param postselection_qubit: Measured qubit to detect leakage error.
-    :type postselection_qubit: Qubit
     :param postselection_bit: Leakage detection result is written to this bit.
-    :type postselection_bit: Bit
     :return: Circuit for detecting leakage errors for specified ids.
-    :rtype: Circuit
     """
     c = Circuit()
     c.add_qubit(circuit_qubit)
@@ -63,13 +59,10 @@ def get_detection_circuit(circuit: Circuit, n_device_qubits: int) -> Circuit:
     additional Bit are written to a new register "leakage_detection_bit".
 
     :param circuit: Circuit to have leakage detection added.
-    :type circuit: Circuit
     :param n_device_qubits: Total number of qubits supported by the device
         being compiled to.
-    :type n_device_qubits: int
 
     :return: Circuit with leakage detection circuitry added.
-    :rtype: Circuit
     """
     n_qubits: int = circuit.n_qubits
     if n_qubits == 0:

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -700,7 +700,7 @@ class QuantinuumBackend(Backend):
         See :py:meth:`pytket.backends.Backend.process_circuits`.
 
         Supported kwargs
-        ================
+        ^^^^^^^^^^^^^^^^
 
         * `postprocess`: apply end-of-circuit simplifications and classical
           postprocessing to improve fidelity of results (bool, default False)

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -715,7 +715,7 @@ class QuantinuumBackend(Backend):
         * `pytketpass`: a ``pytket.passes.BasePass`` intended to be applied
            by the backend (beta feature, may be ignored).
         * `no_opt`: if true, requests that the backend perform no optimizations
-        * `allow_2q_gate_rebase`: If true, allow rebasing of the two-qubit gates to a
+        * `allow_2q_gate_rebase`: if true, allow rebasing of the two-qubit gates to a
            higher-fidelity alternative gate at the discretion of the backend
         * `options`: items to add to the "options" dictionary of the request body, as a
           json-style dictionary (in addition to any that were set in the backend

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -699,7 +699,8 @@ class QuantinuumBackend(Backend):
         """
         See :py:meth:`pytket.backends.Backend.process_circuits`.
 
-        Supported kwargs:
+        Supported kwargs
+        ================
 
         * `postprocess`: apply end-of-circuit simplifications and classical
           postprocessing to improve fidelity of results (bool, default False)
@@ -714,7 +715,7 @@ class QuantinuumBackend(Backend):
         * `pytketpass`: a ``pytket.passes.BasePass`` intended to be applied
            by the backend (beta feature, may be ignored).
         * `no_opt`: if true, requests that the backend perform no optimizations
-        * `allow_2q_gate_rebase`: if true, allow rebasing of the two-qubit gates to a
+        * `allow_2q_gate_rebase`: If true, allow rebasing of the two-qubit gates to a
            higher-fidelity alternative gate at the discretion of the backend
         * `options`: items to add to the "options" dictionary of the request body, as a
           json-style dictionary (in addition to any that were set in the backend

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -223,7 +223,7 @@ class QuantinuumBackend(Backend):
     """
     Interface to a Quantinuum device.
     More information about the QuantinuumBackend can be found on this page
-    https://tket.quantinuum.com/extensions/pytket-quantinuum/api/index.html
+    https://tket.quantinuum.com/extensions/pytket-quantinuum/index.html
     """
 
     _supports_shots = True

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -246,22 +246,15 @@ class QuantinuumBackend(Backend):
         """Construct a new Quantinuum backend.
 
         :param device_name: Name of device, e.g. "H1-1"
-        :type device_name: str
         :param label: Job labels used if Circuits have no name, defaults to "job"
-        :type label: Optional[str], optional
         :param simulator: Only applies to simulator devices, options are
             "state-vector" or "stabilizer", defaults to "state-vector"
         :param group: string identifier of a collection of jobs, can be used for usage
           tracking.
-        :type group: Optional[str], optional
         :param provider: select a provider for federated authentication. We currently
             only support 'microsoft', which enables the microsoft Device Flow.
-        :type provider: Optional[str], optional
-        :type simulator: str, optional
         :param api_handler: Instance of API handler, defaults to DEFAULT_API_HANDLER
-        :type api_handler: QuantinuumAPI
         :param compilation_config: Optional compilation configuration
-        :type compilation_config: QuantinuumBackendCompilationConfig
 
         Supported kwargs:
 
@@ -326,9 +319,7 @@ class QuantinuumBackend(Backend):
         e.g. [{'name': 'H1', 'n_qubits': 6}]
 
         :param api_handler: Instance of API handler
-        :type api_handler: QuantinuumAPI
         :return: Dictionaries of machine name and number of qubits.
-        :rtype: List[Dict[str, Any]]
         """
         id_token = api_handler.login()
         if api_handler.online:
@@ -373,9 +364,7 @@ class QuantinuumBackend(Backend):
         See :py:meth:`pytket.backends.Backend.available_devices`.
 
         :param api_handler: Instance of API handler, defaults to DEFAULT_API_HANDLER
-        :type api_handler: Optional[QuantinuumAPI]
         :return: A list of BackendInfo objects for each available Backend.
-        :rtype: List[BackendInfo]
 
         """
         api_handler = kwargs.get("api_handler", DEFAULT_API_HANDLER)
@@ -403,11 +392,8 @@ class QuantinuumBackend(Backend):
 
 
         :param device_name: Name of the device.
-        :type device_name: str
         :param api_handler: Instance of API handler, defaults to DEFAULT_API_HANDLER
-        :type api_handler: QuantinuumAPI
         :return: String of state, e.g. "online"
-        :rtype: str
         """
         res = requests.get(
             f"{api_handler.url}machine/{device_name}",
@@ -469,9 +455,7 @@ class QuantinuumBackend(Backend):
         :param optimisation_level: Allows values of 0,1 or 2, with higher values
             prompting more computationally heavy optimising compilation that
             can lead to reduced gate count in circuits.
-        :type optimisation_level: int
         :return: Compilation pass for compiling circuits to Quantinuum devices
-        :rtype: BasePass
         """
         assert optimisation_level in range(3)
         passlist = [
@@ -554,9 +538,7 @@ class QuantinuumBackend(Backend):
         """Return the corresponding Quantinuum Job ID from a ResultHandle.
 
         :param handle: result handle.
-        :type handle: ResultHandle
         :return: Quantinuum API Job ID string.
-        :rtype: str
         """
         return cast(str, handle[0])
 
@@ -618,44 +600,30 @@ class QuantinuumBackend(Backend):
         """Submit a program directly to the backend.
 
         :param program: program (encoded as string)
-        :type program: str
         :param language: language
-        :type language: Language
         :param n_shots: Number of shots
-        :type n_shots: int
         :param name: Job name, defaults to None
-        :type name: Optional[str], optional
         :param noisy_simulation: Boolean flag to specify whether the simulator should
           perform noisy simulation with an error model defaults to True
-        :type noisy_simulation: bool
         :param group: String identifier of a collection of jobs, can be used for usage
           tracking. Overrides the instance variable `group`, defaults to None
-        :type group: Optional[str], optional
         :param wasm_file_handler: ``WasmFileHandler`` object for linked WASM
             module, defaults to None
-        :type wasm_file_handler: Optional[WasmFileHandler], optional
         :param no_opt: if true, requests that the backend perform no optimizations
-        :type no_opt: bool, defaults to False
         :param allow_2q_gate_rebase: if true, allow rebasing of the two-qubit gates to
            a higher-fidelity alternative gate at the discretion of the backend
-        :type allow_2q_gate_rebase: bool, defaults to False
         :param pytket_pass: ``pytket.passes.BasePass`` intended to be applied
            by the backend (beta feature, may be ignored), defaults to None
-        :type pytket_pass: Optional[BasePass], optional
         :param options: Items to add to the "options" dictionary of the request body
-        :type options: Optional[Dict[str, Any]], optional
         :param request_options: Extra options to add to the request body as a
           json-style dictionary, defaults to None
-        :type request_options: Optional[Dict[str, Any]], optional
         :param results_selection: Ordered list of register names and indices used to
             construct final :py:class:`BackendResult`. If None, all all results are used
             in lexicographic order.
-        :type results_selection: Optional[List[Tuple[str, int]]]
         :raises WasmUnsupported: WASM submitted to backend that does not support it.
         :raises QuantinuumAPIError: API error.
         :raises ConnectionError: Connection to remote API failed
         :return: ResultHandle for submitted job.
-        :rtype: ResultHandle
         """
 
         body: Dict[str, Any] = {
@@ -918,9 +886,7 @@ class QuantinuumBackend(Backend):
 
         :param max_batch_cost: Maximum cost to be used for the batch, if a job
             exceeds the batch max it will be rejected.
-        :type max_batch_cost: int
         :return: Handle for submitted circuit.
-        :rtype: ResultHandle
         """
         self._check_batchable()
 
@@ -955,12 +921,9 @@ class QuantinuumBackend(Backend):
         documentation on remaining parameters.
 
         :param batch_start_job: Handle of first circuit submitted to batch.
-        :type batch_start_job: ResultHandle
         :param batch_end: Boolean flag to signal the final circuit of batch,
             defaults to False
-        :type batch_end: bool, optional
         :return: Handle for submitted circuit.
-        :rtype: ResultHandle
         """
         self._check_batchable()
 
@@ -1046,11 +1009,9 @@ class QuantinuumBackend(Backend):
         Retrieve partial results for a given job, regardless of its current state.
 
         :param handle: handle to results
-        :type handle: ResultHandle
 
         :return: A tuple containing the results and circuit status.
             If no results are available, the first element is None.
-        :rtype: Tuple[Optional[BackendResult], CircuitStatus]
         """
         handle = self._update_result_handle(handle)
         job_id = self.get_jobid(handle)
@@ -1143,18 +1104,13 @@ class QuantinuumBackend(Backend):
 
         :param circuit: Circuit to calculate runtime estimate for. Must be valid for
             backend.
-        :type circuit: Circuit
         :param n_shots: Number of shots.
-        :type n_shots: int
         :param syntax_checker: Optional. Name of the syntax checker to use to get cost.
             For example for the "H1-1" device that would be "H1-1SC".
             For most devices this is automatically inferred, default=None.
-        :type syntax_checker: str
         :param use_websocket: Optional. Boolean flag to use a websocket connection.
-        :type use_websocket: bool
         :raises ValueError: Circuit is not valid, needs to be compiled.
         :return: Cost in HQC to execute the shots.
-        :rtype: float
         """
         if not self.valid_circuit(circuit):
             raise ValueError(


### PR DESCRIPTION
We now use the `sphinx-autodoc-typehints` extension. With this types can be inferred from the source code so we don't need to specify them twice anymore.