### PR TITLE
Make `QuantinuumBackend.cost()` safe

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* ``QuantinuumBackend.cost()`` now raises an error if the ``syntax_checker``
+  argument doesn't correspond to the device's reported syntax checker or if it
+  specifies a device that isn't a syntax checker; and the method returns 0 if
+  called on syntax-checker backends.
+
 0.26.0 (November 2023)
 ----------------------
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1122,6 +1122,11 @@ class QuantinuumBackend(Backend):
                 + " Try running `backend.get_compiled_circuit` first"
             )
 
+        if self._MACHINE_DEBUG:
+            return 0.0
+
+        assert self.backend_info is not None
+
         if self.backend_info.get_misc("system_type") == "syntax checker":
             return 0.0
 
@@ -1145,6 +1150,7 @@ class QuantinuumBackend(Backend):
                     "parameter (it will normally have a name ending in 'SC')."
                 )
         backend = QuantinuumBackend(syntax_checker_name, api_handler=self.api_handler)
+        assert backend.backend_info is not None
         if backend.backend_info.get_misc("system_type") != "syntax checker":
             raise ValueError(f"Device {backend._device_name} is not a syntax checker.")
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1130,6 +1130,11 @@ class QuantinuumBackend(Backend):
                 " try setting one explicitly with the ``syntax_checker`` parameter"
             )
 
+        if syntax_checker.get_misc("system_type") != "syntax_checker":
+            raise ValueError(
+                f"Device {syntax_checker.device_name} is not a syntax checker."
+            )
+
         backend = QuantinuumBackend(
             cast(str, syntax_checker), api_handler=self.api_handler
         )

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1140,8 +1140,9 @@ class QuantinuumBackend(Backend):
                 syntax_checker_name = syntax_checker
             else:
                 raise NoSyntaxChecker(
-                    "Could not find syntax checker for this backend,"
-                    " try setting one explicitly with the ``syntax_checker`` parameter"
+                    "Could not find syntax checker for this backend, "
+                    "try setting one explicitly with the ``syntax_checker`` "
+                    "parameter (it will normally have a name ending in 'SC')."
                 )
         backend = QuantinuumBackend(syntax_checker_name, api_handler=self.api_handler)
         if backend.backend_info.get_misc("system_type") != "syntax checker":

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -362,14 +362,7 @@ def test_cost_estimate_wrong_syntax_checker(
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
-    "authenticated_quum_backend",
-    [
-        {"device_name": name}
-        for name in [
-            *pytest.ALL_SIMULATOR_NAMES,  # type: ignore
-        ]
-    ],
-    indirect=True,
+    "authenticated_quum_backend", [{"device_name": "H1-1E"}], indirect=True
 )
 @pytest.mark.timeout(120)
 def test_cost_estimate_bad_syntax_checker(
@@ -378,7 +371,7 @@ def test_cost_estimate_bad_syntax_checker(
     b = authenticated_quum_backend
     c = Circuit(1).PhasedX(0.5, 0.5, 0).measure_all()
     with pytest.raises(ValueError):
-        _ = b.cost(c, 10, syntax_checker="H1-1")
+        _ = b.cost(c, 10, syntax_checker="H2-1E")
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -340,18 +340,42 @@ def test_cost_estimate(
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [
+        {"device_name": name}
+        for name in [
+            *pytest.ALL_QUANTUM_HARDWARE_NAMES,  # type: ignore
+        ]
+    ],
+    indirect=True,
+)
 @pytest.mark.timeout(120)
-def test_cost_estimate_wrong_syntax_checker() -> None:
-    b = QuantinuumBackend("H1-1")
+def test_cost_estimate_wrong_syntax_checker(
+    authenticated_quum_backend: QuantinuumBackend,
+) -> None:
+    b = authenticated_quum_backend
     c = Circuit(1).PhasedX(0.5, 0.5, 0).measure_all()
     with pytest.raises(ValueError):
-        _ = b.cost(c, 10, syntax_checker="H1-2SC")
+        _ = b.cost(c, 10, syntax_checker="H6-2SC")
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [
+        {"device_name": name}
+        for name in [
+            *pytest.ALL_SIMULATOR_NAMES,  # type: ignore
+        ]
+    ],
+    indirect=True,
+)
 @pytest.mark.timeout(120)
-def test_cost_estimate_bad_syntax_checker() -> None:
-    b = QuantinuumBackend("H1-1E")
+def test_cost_estimate_bad_syntax_checker(
+    authenticated_quum_backend: QuantinuumBackend,
+) -> None:
+    b = authenticated_quum_backend
     c = Circuit(1).PhasedX(0.5, 0.5, 0).measure_all()
     with pytest.raises(ValueError):
         _ = b.cost(c, 10, syntax_checker="H1-1")
@@ -746,7 +770,7 @@ def test_wasm(
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
-    "authenticated_quum_backend", [{"device_name": "H1-1"}], indirect=True
+    "authenticated_quum_backend", [{"device_name": "H1-1E"}], indirect=True
 )
 @pytest.mark.timeout(120)
 def test_wasm_costs(
@@ -761,7 +785,7 @@ def test_wasm_costs(
     b = authenticated_quum_backend
 
     c = b.get_compiled_circuit(c)
-    costs = b.cost(c, n_shots=10, wasm_file_handler=wasfile)
+    costs = b.cost(c, n_shots=10, syntax_checker="H1-1SC", wasm_file_handler=wasfile)
     if costs is None:
         pytest.skip("API is flaky, sometimes returns None unexpectedly.")
     assert isinstance(costs, float)


### PR DESCRIPTION
Closes #291 .

(The argument is still needed for the emulators, but this ensures it won't accidentally incur costs.)