### PR TITLE
Add local-emulator backends as optional feature

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -148,7 +148,7 @@ jobs:
         ./.github/workflows/docs/check-build-docs
 
   qa_checks:
-    name: Run tests with QA endpoint and local simulator
+    name: Run backend tests with QA endpoint
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
@@ -158,7 +158,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install module
-      run: python -m pip install -v -e .[pecos]
+      run: python -m pip install -v -e .
     - name: Install test requirements
       run: python -m pip install --pre -r tests/test-requirements.txt
     - name: Run tests with QA endpoint
@@ -170,7 +170,7 @@ jobs:
         PYTKET_REMOTE_QUANTINUUM_PASSWORD: ${{ secrets.PYTKET_REMOTE_QUANTINUUM_PASSWORD_QA }}
         PYTKET_REMOTE_QUANTINUUM_EMULATORS_ONLY: 1
       working-directory: ./tests
-      run: pytest
+      run: pytest integration/
 
   publish_to_pypi:
     name: Publish to pypi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -162,6 +162,8 @@ jobs:
     - name: Install test requirements
       run: python -m pip install --pre -r tests/test-requirements.txt
     - name: Run local-emulator tests
+      env:
+        PYTKET_RUN_REMOTE_TESTS: 1
       working-directory: ./tests
       run: pytest integration/local_emulator_test.py
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -147,6 +147,24 @@ jobs:
       run: |
         ./.github/workflows/docs/check-build-docs
 
+  pecos_checks:
+    name: Run local-emulator tests
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install module
+      run: python -m pip install -v -e .[pecos]
+    - name: Install test requirements
+      run: python -m pip install --pre -r tests/test-requirements.txt
+    - name: Run local-emulator tests
+      working-directory: ./tests
+      run: pytest integration/local_emulator_test.py
+
   qa_checks:
     name: Run backend tests with QA endpoint
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -148,7 +148,7 @@ jobs:
         ./.github/workflows/docs/check-build-docs
 
   qa_checks:
-    name: Run backend tests with QA endpoint
+    name: Run tests with QA endpoint and local simulator
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
@@ -158,7 +158,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install module
-      run: python -m pip install -v -e .
+      run: python -m pip install -v -e .[pecos]
     - name: Install test requirements
       run: python -m pip install --pre -r tests/test-requirements.txt
     - name: Run tests with QA endpoint
@@ -170,7 +170,7 @@ jobs:
         PYTKET_REMOTE_QUANTINUUM_PASSWORD: ${{ secrets.PYTKET_REMOTE_QUANTINUUM_PASSWORD_QA }}
         PYTKET_REMOTE_QUANTINUUM_EMULATORS_ONLY: 1
       working-directory: ./tests
-      run: pytest integration/
+      run: pytest
 
   publish_to_pypi:
     name: Publish to pypi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -170,7 +170,7 @@ jobs:
         PYTKET_REMOTE_QUANTINUUM_PASSWORD: ${{ secrets.PYTKET_REMOTE_QUANTINUUM_PASSWORD_QA }}
         PYTKET_REMOTE_QUANTINUUM_EMULATORS_ONLY: 1
       working-directory: ./tests
-      run: pytest integration/backend_test.py
+      run: pytest integration/
 
   publish_to_pypi:
     name: Publish to pypi

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Unreleased
   argument doesn't correspond to the device's reported syntax checker or if it
   specifies a device that isn't a syntax checker; and the method returns 0 if
   called on syntax-checker backends.
+* Add partial support for local emulator backends, if installed with the
+  ``pecos`` option.
 
 0.26.0 (November 2023)
 ----------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -244,7 +244,31 @@ Once a batch is submitted, jobs can continue to be added to the batch, ending ei
 
 If the total HQCs for jobs in a batch hit this limit or a smaller limit set by the user, those jobs *will not be cancelled*. Instead, they will continue to run as regular jobs in the queue instead of as a batch.
 
+Local Emulators
+===============
 
+If ``pytket-quantinuum`` is installed with the ``pecos`` option:
+
+::
+
+  pip install pytket-quantinuum[pecos]
+
+then it is possible to run circuits on an emulator running on the local machine
+instead of using the remote emulator.
+
+For example, the "H1-1" device would have a counterpart device called "H1-1LE".
+Running circuits on this device would be similar to using the "H1-1" device or
+the remote emulator ("H1-1E"), but would not incur any cost in HQCs (and for
+small circuits would typically be faster).
+
+Currently this emulation is noiseless, so if noisy emulation is required it is
+still necessary to use the remote emulators (such as "H1-1E").
+
+A few of the ``QuantinuumBackend`` methods (``submit_program()``, ``cancel()``,
+``circuit_status()``, ``get_partial_result()``, and ``cost()``) are not
+available for local-emulator backends.
+
+This option requires Python 3.10 or later.
 
 .. toctree::
     api.rst

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -265,8 +265,7 @@ Currently this emulation is noiseless, so if noisy emulation is required it is
 still necessary to use the remote emulators (such as "H1-1E").
 
 A few of the ``QuantinuumBackend`` methods (``submit_program()``, ``cancel()``,
-``get_partial_result()``, and ``cost()``) are not available for local-emulator
-backends.
+and ``get_partial_result()``) are not available for local-emulator backends.
 
 This option requires Python 3.10 or later.
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -269,6 +269,10 @@ and ``get_partial_result()``) are not available for local-emulator backends.
 
 This option requires Python 3.10 or later.
 
+**Note**: This is still an experimental feature. Currently not all circuits can
+be emulated locally. In particular, classical operations are not fully
+supported.
+
 .. toctree::
     api.rst
     changelog.rst

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -265,8 +265,8 @@ Currently this emulation is noiseless, so if noisy emulation is required it is
 still necessary to use the remote emulators (such as "H1-1E").
 
 A few of the ``QuantinuumBackend`` methods (``submit_program()``, ``cancel()``,
-``circuit_status()``, ``get_partial_result()``, and ``cost()``) are not
-available for local-emulator backends.
+``get_partial_result()``, and ``cost()``) are not available for local-emulator
+backends.
 
 This option requires Python 3.10 or later.
 

--- a/pytket/extensions/quantinuum/__init__.py
+++ b/pytket/extensions/quantinuum/__init__.py
@@ -24,4 +24,5 @@ from .backends import (
     QuantinuumBackendCompilationConfig,
     Language,
     prune_shots_detected_as_leaky,
+    have_pecos,
 )

--- a/pytket/extensions/quantinuum/backends/__init__.py
+++ b/pytket/extensions/quantinuum/backends/__init__.py
@@ -15,6 +15,11 @@
 """Backends for processing pytket circuits with Quantinuum devices
 """
 
-from .quantinuum import QuantinuumBackend, QuantinuumBackendCompilationConfig, Language
+from .quantinuum import (
+    QuantinuumBackend,
+    QuantinuumBackendCompilationConfig,
+    Language,
+    have_pecos,
+)
 from .api_wrappers import QuantinuumAPI, QuantinuumAPIOffline
 from .leakage_gadget import prune_shots_detected_as_leaky

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1031,13 +1031,16 @@ class QuantinuumBackend(Backend):
     def circuit_status(
         self, handle: ResultHandle, **kwargs: KwargTypes
     ) -> CircuitStatus:
-        if self.is_local_emulator:
-            raise NotImplemented("circuit_status() not supported with local emulator")
         handle = self._update_result_handle(handle)
         self._check_handle_type(handle)
         jobid = self.get_jobid(handle)
-        if self._MACHINE_DEBUG or jobid.startswith(_DEBUG_HANDLE_PREFIX):
+        if (
+            self._MACHINE_DEBUG
+            or jobid.startswith(_DEBUG_HANDLE_PREFIX)
+            or self.is_local_emulator
+        ):
             return CircuitStatus(StatusEnum.COMPLETED)
+
         use_websocket = cast(bool, kwargs.get("use_websocket", True))
         # TODO check queue position and add to message
         try:

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1204,8 +1204,6 @@ class QuantinuumBackend(Backend):
         :raises ValueError: Circuit is not valid, needs to be compiled.
         :return: Cost in HQC to execute the shots.
         """
-        if self.is_local_emulator:
-            raise NotImplemented("cost() not supported with local emulator")
         if not self.valid_circuit(circuit):
             raise ValueError(
                 "Circuit does not satisfy predicates of backend."
@@ -1217,7 +1215,9 @@ class QuantinuumBackend(Backend):
 
         assert self.backend_info is not None
 
-        if self.backend_info.get_misc("system_type") == "syntax checker":
+        if (
+            self.backend_info.get_misc("system_type") == "syntax checker"
+        ) or self.is_local_emulator:
             return 0.0
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pyjwt ~= 2.4",
         "msal ~= 1.18",
     ],
-    extras_require={"pecos": ["pytket-pecos >= 0.1.2"]},
+    extras_require={"pecos": ["pytket-pecos >= 0.1.3"]},
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "pyjwt ~= 2.4",
         "msal ~= 1.18",
     ],
+    extras_require={"pecos": ["pytket-pecos >= 0.1.2"]},
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pyjwt ~= 2.4",
         "msal ~= 1.18",
     ],
-    extras_require={"pecos": ["pytket-pecos >= 0.1.3"]},
+    extras_require={"pecos": ["pytket-pecos >= 0.1.4"]},
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from _pytest.fixtures import SubRequest
 from requests_mock.mocker import Mocker
 import jwt
 
-from pytket.extensions.quantinuum import QuantinuumBackend, have_pecos
+from pytket.extensions.quantinuum import QuantinuumBackend
 from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
 from pytket.extensions.quantinuum.backends.credential_storage import (
     MemoryCredentialStorage,
@@ -46,14 +46,10 @@ ALL_SYNTAX_CHECKER_NAMES = [
     "H2-1SC",
 ]
 
-ALL_LOCAL_SIMULATOR_NAMES = (
-    [
-        "H1-1LE",
-        "H2-1LE",
-    ]
-    if have_pecos()
-    else []
-)
+ALL_LOCAL_SIMULATOR_NAMES = [
+    "H1-1LE",
+    "H2-1LE",
+]
 
 ALL_DEVICE_NAMES = [
     *ALL_QUANTUM_HARDWARE_NAMES,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from _pytest.fixtures import SubRequest
 from requests_mock.mocker import Mocker
 import jwt
 
-from pytket.extensions.quantinuum import QuantinuumBackend
+from pytket.extensions.quantinuum import QuantinuumBackend, have_pecos
 from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
 from pytket.extensions.quantinuum.backends.credential_storage import (
     MemoryCredentialStorage,
@@ -46,6 +46,15 @@ ALL_SYNTAX_CHECKER_NAMES = [
     "H2-1SC",
 ]
 
+ALL_LOCAL_SIMULATOR_NAMES = (
+    [
+        "H1-1LE",
+        "H2-1LE",
+    ]
+    if have_pecos()
+    else []
+)
+
 ALL_DEVICE_NAMES = [
     *ALL_QUANTUM_HARDWARE_NAMES,
     *ALL_SIMULATOR_NAMES,
@@ -64,6 +73,7 @@ def pytest_configure() -> None:
     pytest.ALL_SYNTAX_CHECKER_NAMES = ALL_SYNTAX_CHECKER_NAMES
     pytest.ALL_SIMULATOR_NAMES = ALL_SIMULATOR_NAMES
     pytest.ALL_QUANTUM_HARDWARE_NAMES = ALL_QUANTUM_HARDWARE_NAMES
+    pytest.ALL_LOCAL_SIMULATOR_NAMES = ALL_LOCAL_SIMULATOR_NAMES
 
 
 def pytest_make_parametrize_id(
@@ -174,8 +184,8 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
             "batching": True,
             "wasm": True,
         },
-        {"name": "H1", "n_qubits": 20},
-        {"name": "H2", "n_qubits": 32},
+        {"name": "H1", "n_qubits": 20, "system_type": "hardware"},
+        {"name": "H2", "n_qubits": 32, "system_type": "hardware"},
     ]
 
 

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -1,0 +1,31 @@
+# Copyright 2020-2023 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import Counter
+import pytest
+from pytket.circuit import Circuit
+from pytket.extensions.quantinuum import QuantinuumBackend, have_pecos
+
+
+@pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+def test_local_emulator(device_name: str) -> None:
+    b = QuantinuumBackend(device_name)
+    assert b.is_local_emulator
+    c0 = Circuit(2).X(0).CX(0, 1).measure_all()
+    c = b.get_compiled_circuit(c0)
+    h = b.process_circuit(c, n_shots=10)
+    r = b.get_result(h)
+    counts = r.get_counts()
+    assert counts == Counter({(1, 1): 10})

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -110,6 +110,21 @@ def test_multireg(device_name: str) -> None:
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
 @pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
+def test_basic_classical(device_name: str) -> None:
+    b = QuantinuumBackend(device_name)
+    c = Circuit(1, 3)
+    c.H(0)
+    c.Measure(0, 0)
+    c.add_c_setbits([True, False, True], c.bits)
+    c = b.get_compiled_circuit(c)
+    n_shots = 10
+    counts = b.run_circuit(c, n_shots=n_shots).get_counts()
+    assert counts == Counter({(1, 0, 1): n_shots})
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
 @pytest.mark.xfail(reason="https://github.com/CQCL/pytket-phir/issues/61")
 def test_classical(device_name: str) -> None:
     c = Circuit(1)

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -38,7 +38,7 @@ REASON = (
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
 def test_local_emulator(device_name: str) -> None:
     b = QuantinuumBackend(device_name)
     assert b.is_local_emulator
@@ -53,7 +53,7 @@ def test_local_emulator(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
 def test_circuit_with_conditional(device_name: str) -> None:
     b = QuantinuumBackend(device_name)
     c0 = Circuit(2, 2).H(0)
@@ -70,7 +70,7 @@ def test_circuit_with_conditional(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
 def test_results_order(device_name: str) -> None:
     b = QuantinuumBackend(device_name)
     c0 = Circuit(2).X(0).measure_all()
@@ -83,7 +83,7 @@ def test_results_order(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
 def test_multireg(device_name: str) -> None:
     b = QuantinuumBackend(device_name)
     c = Circuit()
@@ -102,14 +102,14 @@ def test_multireg(device_name: str) -> None:
     c = b.get_compiled_circuit(c)
 
     n_shots = 10
-    counts = b.run_circuit(c, n_shots=n_shots).get_counts()  # type: ignore
+    counts = b.run_circuit(c, n_shots=n_shots).get_counts()
     assert sum(counts.values()) == 10
     assert all(v0 == v1 for v0, v1 in counts.keys())
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
 @pytest.mark.xfail(reason="https://github.com/CQCL/pytket-phir/issues/61")
 def test_classical(device_name: str) -> None:
     c = Circuit(1)
@@ -146,8 +146,8 @@ def test_classical(device_name: str) -> None:
     c.X(0, condition=reg_leq(a, 1))
     c.Phase(0, condition=a[0])
 
-    b = QuantinuumBackend(device_name)
+    backend = QuantinuumBackend(device_name)
 
-    c = b.get_compiled_circuit(c)
-    counts = b.run_circuit(c, n_shots=10).get_counts()
+    c = backend.get_compiled_circuit(c)
+    counts = backend.run_circuit(c, n_shots=10).get_counts()
     assert len(counts.values()) == 1

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -110,7 +110,8 @@ def test_multireg(device_name: str) -> None:
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
 @pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
-def test_basic_classical(device_name: str) -> None:
+@pytest.mark.xfail(reason="bug in pytket-phir?")
+def test_setbits(device_name: str) -> None:
     b = QuantinuumBackend(device_name)
     c = Circuit(1, 3)
     c.H(0)
@@ -141,9 +142,7 @@ def test_classical(device_name: str) -> None:
 
     c.add_classicalexpbox_register(a + b, d.to_list())
     c.add_classicalexpbox_register(a - b, d.to_list())
-
     c.add_classicalexpbox_register(a * b // d, d.to_list())
-
     c.add_classicalexpbox_register(a << 1, a.to_list())
     c.add_classicalexpbox_register(a >> 1, b.to_list())
 

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -33,6 +33,7 @@ def test_local_emulator(device_name: str) -> None:
     assert b.is_local_emulator
     c0 = Circuit(2).X(0).CX(0, 1).measure_all()
     c = b.get_compiled_circuit(c0)
+    assert b.cost(c, n_shots=10) == 0.0
     h = b.process_circuit(c, n_shots=10)
     r = b.get_result(h)
     counts = r.get_counts()

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -54,3 +54,16 @@ def test_circuit_with_conditional(device_name: str) -> None:
     counts = r.get_counts()
     assert sum(counts.values()) == 10
     assert all(v0 == v1 for v0, v1 in counts.keys())
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+def test_results_order(device_name: str) -> None:
+    b = QuantinuumBackend(device_name)
+    c0 = Circuit(2).X(0).measure_all()
+    c = b.get_compiled_circuit(c0)
+    h = b.process_circuit(c, n_shots=10)
+    r = b.get_result(h)
+    counts = r.get_counts()
+    assert counts == Counter({(1, 0): 10})

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -13,11 +13,19 @@
 # limitations under the License.
 
 from collections import Counter
+import os
 import pytest
 from pytket.circuit import Circuit
 from pytket.extensions.quantinuum import QuantinuumBackend, have_pecos
 
+skip_remote_tests: bool = os.getenv("PYTKET_RUN_REMOTE_TESTS") is None
 
+REASON = (
+    "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of Quantinuum username)"
+)
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
 @pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
 def test_local_emulator(device_name: str) -> None:

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -37,3 +37,20 @@ def test_local_emulator(device_name: str) -> None:
     r = b.get_result(h)
     counts = r.get_counts()
     assert counts == Counter({(1, 1): 10})
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
+@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)
+def test_circuit_with_conditional(device_name: str) -> None:
+    b = QuantinuumBackend(device_name)
+    c0 = Circuit(2, 2).H(0)
+    c0.Measure(0, 0)
+    c0.X(1, condition_bits=[0], condition_value=1)
+    c0.Measure(1, 1)
+    c = b.get_compiled_circuit(c0)
+    h = b.process_circuit(c, n_shots=10)
+    r = b.get_result(h)
+    counts = r.get_counts()
+    assert sum(counts.values()) == 10
+    assert all(v0 == v1 for v0, v1 in counts.keys())

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -38,9 +38,13 @@ REASON = (
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
-def test_local_emulator(device_name: str) -> None:
-    b = QuantinuumBackend(device_name)
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
+    indirect=True,
+)
+def test_local_emulator(authenticated_quum_backend: QuantinuumBackend) -> None:
+    b = authenticated_quum_backend
     assert b.is_local_emulator
     c0 = Circuit(2).X(0).CX(0, 1).measure_all()
     c = b.get_compiled_circuit(c0)
@@ -53,9 +57,15 @@ def test_local_emulator(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
-def test_circuit_with_conditional(device_name: str) -> None:
-    b = QuantinuumBackend(device_name)
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
+    indirect=True,
+)
+def test_circuit_with_conditional(
+    authenticated_quum_backend: QuantinuumBackend,
+) -> None:
+    b = authenticated_quum_backend
     c0 = Circuit(2, 2).H(0)
     c0.Measure(0, 0)
     c0.X(1, condition_bits=[0], condition_value=1)
@@ -70,9 +80,13 @@ def test_circuit_with_conditional(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
-def test_results_order(device_name: str) -> None:
-    b = QuantinuumBackend(device_name)
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
+    indirect=True,
+)
+def test_results_order(authenticated_quum_backend: QuantinuumBackend) -> None:
+    b = authenticated_quum_backend
     c0 = Circuit(2).X(0).measure_all()
     c = b.get_compiled_circuit(c0)
     h = b.process_circuit(c, n_shots=10)
@@ -83,9 +97,13 @@ def test_results_order(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
-def test_multireg(device_name: str) -> None:
-    b = QuantinuumBackend(device_name)
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
+    indirect=True,
+)
+def test_multireg(authenticated_quum_backend: QuantinuumBackend) -> None:
+    b = authenticated_quum_backend
     c = Circuit()
     q1 = Qubit("q1", 0)
     q2 = Qubit("q2", 0)
@@ -109,10 +127,14 @@ def test_multireg(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
+    indirect=True,
+)
 @pytest.mark.xfail(reason="bug in pytket-phir?")
-def test_setbits(device_name: str) -> None:
-    b = QuantinuumBackend(device_name)
+def test_setbits(authenticated_quum_backend: QuantinuumBackend) -> None:
+    b = authenticated_quum_backend
     c = Circuit(1, 3)
     c.H(0)
     c.Measure(0, 0)
@@ -125,9 +147,13 @@ def test_setbits(device_name: str) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
-@pytest.mark.parametrize("device_name", pytest.ALL_LOCAL_SIMULATOR_NAMES)  # type: ignore
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
+    indirect=True,
+)
 @pytest.mark.xfail(reason="https://github.com/CQCL/pytket-phir/issues/61")
-def test_classical(device_name: str) -> None:
+def test_classical(authenticated_quum_backend: QuantinuumBackend) -> None:
     c = Circuit(1)
     a = c.add_c_register("a", 8)
     b = c.add_c_register("b", 10)
@@ -160,7 +186,7 @@ def test_classical(device_name: str) -> None:
     c.X(0, condition=reg_leq(a, 1))
     c.Phase(0, condition=a[0])
 
-    backend = QuantinuumBackend(device_name)
+    backend = authenticated_quum_backend
 
     c = backend.get_compiled_circuit(c)
     counts = backend.run_circuit(c, n_shots=10).get_counts()

--- a/tests/unit/api1_test.py
+++ b/tests/unit/api1_test.py
@@ -27,7 +27,11 @@ from requests_mock.mocker import Mocker
 
 from pytket.backends import ResultHandle, StatusEnum
 from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
-from pytket.extensions.quantinuum.backends import QuantinuumBackend, Language
+from pytket.extensions.quantinuum.backends import (
+    QuantinuumBackend,
+    Language,
+    have_pecos,
+)
 from pytket.circuit import Circuit
 from pytket.architecture import FullyConnected
 from pytket.extensions.quantinuum.backends.quantinuum import (
@@ -478,7 +482,7 @@ def test_available_devices(
     )
 
     devices = QuantinuumBackend.available_devices(api_handler=mock_quum_api_handler)
-    backinfo0, backinfo1 = devices
+    backinfo0 = devices[0]
 
     assert backinfo0.device_name == mock_machine_info["name"]
     assert backinfo0.architecture == FullyConnected(mock_machine_info["n_qubits"], "q")
@@ -495,22 +499,27 @@ def test_available_devices(
         "batching": True,
         "wasm": True,
     }
-    assert backinfo1.name == "QuantinuumBackend"
-    assert backinfo1.device_name == mock_machine_info["name"] + "LE"
-    assert backinfo1.architecture == FullyConnected(mock_machine_info["n_qubits"], "q")
-    assert backinfo1.version == __extension_version__
-    assert backinfo1.supports_fast_feedforward == True
-    assert backinfo1.supports_midcircuit_measurement == True
-    assert backinfo1.supports_reset == True
-    assert backinfo1.n_cl_reg == 120
-    assert backinfo1.misc == {
-        "n_shots": 10000,
-        "system_type": "local_emulator",
-        "syntax_checker": "H9-27SC",
-        "batching": False,
-        "wasm": True,
-    }
     assert backinfo0.name == "QuantinuumBackend"
+
+    if have_pecos():
+        backinfo1 = devices[1]
+        assert backinfo1.device_name == mock_machine_info["name"] + "LE"
+        assert backinfo1.architecture == FullyConnected(
+            mock_machine_info["n_qubits"], "q"
+        )
+        assert backinfo1.version == __extension_version__
+        assert backinfo1.supports_fast_feedforward == True
+        assert backinfo1.supports_midcircuit_measurement == True
+        assert backinfo1.supports_reset == True
+        assert backinfo1.n_cl_reg == 120
+        assert backinfo1.misc == {
+            "n_shots": 10000,
+            "system_type": "local_emulator",
+            "syntax_checker": "H9-27SC",
+            "batching": False,
+            "wasm": True,
+        }
+        assert backinfo1.name == "QuantinuumBackend"
 
 
 def test_submit_qasm_api(


### PR DESCRIPTION
When pytket-quantinuum is installed with the `pecos` option (`pip install pytket-quantinuum[pecos]`), local-emulator backends become available.

For every hardware device detected as available, a local-emulator device is created, having the same name with "LE" appended. This device presents the same API as the actual device (with the exception of a few methods that are not available), but circuit execution is emulated (noiselessly) on the user's machine using PECOS.

Because of current limitations in pytket-phir, functionality is limited: circuits containing classical operations or WASM are not supported. Support for these will be added in due course. Noise emulation will also be added as and when the real devices' noise information becomes available over the API.

I've added a section to the documentation, making clear that this is still an experimental feature with limited functionality.