### PR TITLE
Add credential_storage module to API doc

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,3 +29,6 @@ Consult the `notebooks <https://github.com/CQCL/pytket-quantinuum/tree/develop/e
 
 .. automodule:: pytket.extensions.quantinuum.backends.leakage_gadget
     :members:
+
+.. automodule:: pytket.extensions.quantinuum.backends.credential_storage
+    :members: MemoryCredentialStorage, QuantinuumConfigCredentialStorage


### PR DESCRIPTION
# Description

Add two credential storage classes to API doc

# Related issues

Resolves #290 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
