### PR TITLE
Update pytket_pecos requirement to 0.1.9 and update classical tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,7 +114,7 @@ jobs:
         ./.github/workflows/build-test nomypy integration
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       if: |
         github.event_name == 'push' ||
         github.event_name == 'pull_request' ||
@@ -122,8 +122,8 @@ jobs:
         github.event_name == 'workflow_dispatch'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
-    - name: Build and test (3.11)
+        python-version: '3.12'
+    - name: Build and test (3.12)
       if: |
         github.event_name == 'push' ||
         github.event_name == 'pull_request' ||
@@ -153,10 +153,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install module
       run: python -m pip install -v -e .[pecos]
     - name: Install test requirements

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,7 +114,7 @@ jobs:
         ./.github/workflows/build-test nomypy integration
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       if: |
         github.event_name == 'push' ||
         github.event_name == 'pull_request' ||
@@ -122,8 +122,8 @@ jobs:
         github.event_name == 'workflow_dispatch'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
-    - name: Build and test (3.12)
+        python-version: '3.11'
+    - name: Build and test (3.11)
       if: |
         github.event_name == 'push' ||
         github.event_name == 'pull_request' ||
@@ -153,10 +153,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.11'
     - name: Install module
       run: python -m pip install -v -e .[pecos]
     - name: Install test requirements

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ General:
 
 * Python 3.12 support added, 3.9 dropped.
 * pytket dependency updated to 1.24
+* pytket_pecos dependency updated to 0.1.9.
 
 0.27.0 (January 2024)
 ---------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -254,8 +254,7 @@ If ``pytket-quantinuum`` is installed with the ``pecos`` option:
   pip install pytket-quantinuum[pecos]
 
 then it is possible to run circuits on an emulator running on the local machine
-instead of using the remote emulator. Note that that installation option is only
-available for python 3.10 and 3.11.
+instead of using the remote emulator.
 
 For example, the "H1-1" device would have a counterpart device called "H1-1LE".
 Running circuits on this device would be similar to using the "H1-1" device or

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pyjwt ~= 2.4",
         "msal ~= 1.18",
     ],
-    extras_require={"pecos": ["pytket-pecos ~= 0.1.8"]},
+    extras_require={"pecos": ["pytket-pecos ~= 0.1.9"]},
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -248,8 +248,8 @@ def test_classical_2(authenticated_quum_backend: QuantinuumBackend) -> None:
     circ.X(0)
     circ.Measure(Qubit(0), a[1])
     backend = authenticated_quum_backend
-    c = backend.get_compiled_circuit(circ)
-    counts = backend.run_circuit(c, n_shots=10).get_counts()
+    cc = backend.get_compiled_circuit(circ)
+    counts = backend.run_circuit(cc, n_shots=10).get_counts()
     assert len(counts.keys()) == 1
 
 
@@ -278,8 +278,8 @@ def test_classical_3(authenticated_quum_backend: QuantinuumBackend) -> None:
 
     backend = authenticated_quum_backend
 
-    c = backend.get_compiled_circuit(circ)
-    counts = backend.run_circuit(c, n_shots=10).get_counts()
+    cc = backend.get_compiled_circuit(circ)
+    counts = backend.run_circuit(cc, n_shots=10).get_counts()
     assert len(counts.keys()) == 1
     result = list(counts.keys())[0]
     assert result == (0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0)


### PR DESCRIPTION
# Description

Some previous "expected fails" now pass, but more bugs exist -- added separate "expected fail" tests for these.

Now the pecos option works with Python 3.12, so remove the note about this in the documentation.

# Related issues

Closes #330 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
