### PR TITLE
Don't raise an exception if a device doesn't have a "system_type".

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -394,7 +394,7 @@ class QuantinuumBackend(Backend):
         devices = []
         for d in jr:
             devices.append(cls._dict_to_backendinfo(copy(d)))
-            if have_pecos() and (d["system_type"] == "hardware"):
+            if have_pecos() and (d.get("system_type") == "hardware"):
                 # Add a local-emulator variant
                 devices.append(cls._dict_to_backendinfo(d, local_emulator=True))
         return devices


### PR DESCRIPTION
# Description

Some internal devices don't have this attribute, so allow for it to be absent.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
