### PR TITLE
Update to pytket-pecos 0.1.10

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Updated pytket_pecos version requirement to 0.1.10.
+
+
 0.28.0 (January 2024)
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pyjwt ~= 2.4",
         "msal ~= 1.18",
     ],
-    extras_require={"pecos": ["pytket-pecos ~= 0.1.9"]},
+    extras_require={"pecos": ["pytket-pecos ~= 0.1.10"]},
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -153,7 +153,6 @@ def test_setbits(authenticated_quum_backend: QuantinuumBackend) -> None:
     [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
     indirect=True,
 )
-@pytest.mark.xfail(reason="https://github.com/CQCL/pytket-phir/issues/92")
 def test_classical_0(authenticated_quum_backend: QuantinuumBackend) -> None:
     c = Circuit(1)
     a = c.add_c_register("a", 8)
@@ -237,7 +236,6 @@ def test_classical_1(authenticated_quum_backend: QuantinuumBackend) -> None:
     [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
     indirect=True,
 )
-@pytest.mark.xfail(reason="https://github.com/CQCL/pytket-phir/issues/91")
 def test_classical_2(authenticated_quum_backend: QuantinuumBackend) -> None:
     circ = Circuit(1)
     a = circ.add_c_register("a", 2)
@@ -260,7 +258,6 @@ def test_classical_2(authenticated_quum_backend: QuantinuumBackend) -> None:
     [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
     indirect=True,
 )
-@pytest.mark.xfail(reason="https://github.com/CQCL/pytket-phir/issues/92")
 def test_classical_3(authenticated_quum_backend: QuantinuumBackend) -> None:
     circ = Circuit(1)
     a = circ.add_c_register("a", 4)


### PR DESCRIPTION
# Description

Update to latest pytket-pecos, which has in turn been updated to latest pytket-phir, which fixes a couple of bugs. Remove "expected failure" annotation from some tests.

# Related issues

Closes #339 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
