### PR TITLE
Fix handling of results in local emulator with non-default classical registers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Fix handling of results in local emulator with non-default classical
+  registers.
+
 0.28.0 (January 2024)
 ---------------------
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1146,7 +1146,7 @@ class QuantinuumBackend(Backend):
                 c0, n_shots, seed = self._local_emulator_handles[handle]
                 emu = Emulator(c0, qsim="state-vector", seed=seed)
                 res = emu.run(n_shots=n_shots)
-                backres = BackendResult(shots=res, ppcirc=ppcirc)
+                backres = BackendResult(c_bits=c0.bits, shots=res, ppcirc=ppcirc)
             else:
                 # TODO exception handling when jobid not found on backend
                 timeout = kwargs.get("timeout")

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -332,3 +332,28 @@ def test_midcircuit_measurement_and_reset(
     n_shots = 10
     counts = b.run_circuit(c, n_shots=n_shots).get_counts()
     assert counts == Counter({(1, 0, 1, 1): n_shots})
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.skipif(not have_pecos(), reason="pecos not installed")
+@pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
+    indirect=True,
+)
+def test_cbits(authenticated_quum_backend: QuantinuumBackend) -> None:
+    circ = Circuit(1)
+    a = circ.add_c_register("a", 2)
+    b = circ.add_c_register("b", 2)
+
+    circ.add_c_setreg(3, a)
+    circ.add_c_copyreg(a, b)
+    circ.X(0)
+    circ.Measure(Qubit(0), a[0])
+
+    backend = authenticated_quum_backend
+
+    cc = backend.get_compiled_circuit(circ)
+    r = backend.run_circuit(cc, n_shots=1)
+    counts = r.get_counts(cbits=list(a))
+    assert counts == Counter({(1, 1): 1})


### PR DESCRIPTION
# Description

Pass the circuit's bits to the constructor of the `BackendResult`.

# Related issues

Fixes #342 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
