### PR TITLE
Add WASM support to local emulators

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,9 +4,10 @@ Changelog
 Unreleased
 ----------
 
-* Updated pytket_pecos version requirement to 0.1.10.
+* Updated pytket_pecos version requirement to 0.1.11.
 * Fix handling of results in local emulator with non-default classical
   registers.
+* Add WASM support to local emulators.
 
 0.28.0 (January 2024)
 ---------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -278,12 +278,6 @@ use the ``QuantinuumAPIOffline`` when constructing the backend:
   api_offline = QuantinuumAPIOffline()
   backend = QuantinuumBackend(device_name="H1-1LE", api_handler = api_offline)
 
-This option requires Python 3.10 or later.
-
-**Note**: This is still an experimental feature. Currently not all circuits can
-be emulated locally. In particular, classical operations are not fully
-supported.
-
 .. toctree::
     api.rst
     changelog.rst

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -289,9 +289,9 @@ class QuantinuumBackend(Backend):
 
         self._process_circuits_options = cast(Dict[str, Any], kwargs.get("options", {}))
 
-        # Map from ResultHandle to (circuit, n_shots, seed)
+        # Map from ResultHandle to (circuit, wasm, n_shots, seed)
         self._local_emulator_handles: Dict[
-            ResultHandle, Tuple[Circuit, int, Optional[int]]
+            ResultHandle, Tuple[Circuit, Optional[WasmFileHandler], int, Optional[int]]
         ] = dict()
 
         self._default_2q_gate = _default_2q_gate(device_name)
@@ -850,7 +850,7 @@ class QuantinuumBackend(Backend):
                     json.dumps(results_selection),
                 )
                 handle_list.append(handle)
-                self._local_emulator_handles[handle] = (c0, n_shots, seed)
+                self._local_emulator_handles[handle] = (c0, wasm_fh, n_shots, seed)
                 if seed is not None:
                     seed += 1
             else:
@@ -1143,8 +1143,8 @@ class QuantinuumBackend(Backend):
                     )
                 from pytket_pecos import Emulator
 
-                c0, n_shots, seed = self._local_emulator_handles[handle]
-                emu = Emulator(c0, qsim="state-vector", seed=seed)
+                c0, wasm, n_shots, seed = self._local_emulator_handles[handle]
+                emu = Emulator(c0, wasm=wasm, qsim="state-vector", seed=seed)
                 res = emu.run(n_shots=n_shots)
                 backres = BackendResult(c_bits=c0.bits, shots=res, ppcirc=ppcirc)
             else:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pyjwt ~= 2.4",
         "msal ~= 1.18",
     ],
-    extras_require={"pecos": ["pytket-pecos ~= 0.1.10"]},
+    extras_require={"pecos": ["pytket-pecos ~= 0.1.11"]},
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -299,8 +299,8 @@ def test_wasm(authenticated_quum_backend: QuantinuumBackend) -> None:
 
     c = b.get_compiled_circuit(c)
     n_shots = 10
-    counts = b.run_circuit(c, n_shots=n_shots).get_counts()
-    assert counts == Counter({(0, 0, 1): n_shots})
+    counts = b.run_circuit(c, wasm_file_handler=wasfile, n_shots=n_shots).get_counts()
+    assert counts == Counter({(1, 0, 0, 0, 0, 0, 0, 0): n_shots})
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -289,7 +289,6 @@ def test_classical_3(authenticated_quum_backend: QuantinuumBackend) -> None:
     [{"device_name": name} for name in pytest.ALL_LOCAL_SIMULATOR_NAMES],  # type: ignore
     indirect=True,
 )
-@pytest.mark.xfail(reason="https://github.com/CQCL/pytket-phir/issues/50")
 def test_wasm(authenticated_quum_backend: QuantinuumBackend) -> None:
     wasfile = WasmFileHandler(str(Path(__file__).parent.parent / "wasm" / "add1.wasm"))
     c = Circuit(1)

--- a/tests/integration/local_emulator_test.py
+++ b/tests/integration/local_emulator_test.py
@@ -300,7 +300,7 @@ def test_wasm(authenticated_quum_backend: QuantinuumBackend) -> None:
 
     c = b.get_compiled_circuit(c)
     n_shots = 10
-    counts = b.run_circuit(c, wasm_file_handler=wasfile, n_shots=n_shots).get_counts()
+    counts = b.run_circuit(c, wasm_file_handler=wasfile, n_shots=n_shots).get_counts()  # type: ignore
     assert counts == Counter({(1, 0, 0, 0, 0, 0, 0, 0): n_shots})
 
 
@@ -330,7 +330,7 @@ def test_wasm_collatz(authenticated_quum_backend: QuantinuumBackend) -> None:
     backend = authenticated_quum_backend
 
     c = backend.get_compiled_circuit(c)
-    h = backend.process_circuit(c, n_shots=10, wasm_file_handler=wasfile)
+    h = backend.process_circuit(c, n_shots=10, wasm_file_handler=wasfile)  # type: ignore
 
     r = backend.get_result(h)
     shots = r.get_shots()


### PR DESCRIPTION
# Description

Update to latest pytket-pecos and add WASM support to local emulators. Add tests. Update docs.

# Related issues
Closes #344 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
