### PR TITLE
Remove xfail for QIR noise test.

### DIFF
--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -541,18 +541,7 @@ def test_shots_bits_edgecases(n_shots, n_bits) -> None:
 @pytest.mark.parametrize(
     "authenticated_quum_backend", [{"device_name": "H1-1E"}], indirect=True
 )
-@pytest.mark.parametrize(
-    "language",
-    [
-        Language.QASM,
-        pytest.param(
-            Language.QIR,
-            marks=pytest.mark.xfail(
-                reason="https://github.com/CQCL/pytket-quantinuum/issues/276"
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("language", [Language.QASM, Language.QIR])
 @pytest.mark.timeout(120)
 def test_simulator(
     authenticated_quum_handler: QuantinuumAPI,


### PR DESCRIPTION
# Description

The issue with noisy QIR simulation seems to be resolved, at least on QA. Therefore we can re-enable this test.

# Related issues

Closes #276 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
