### PR TITLE
Update to pytket-pecos 0.1.15

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,7 +114,7 @@ jobs:
         ./.github/workflows/build-test nomypy integration
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       if: |
         github.event_name == 'push' ||
         github.event_name == 'pull_request' ||
@@ -122,8 +122,8 @@ jobs:
         github.event_name == 'workflow_dispatch'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
-    - name: Build and test (3.11)
+        python-version: '3.12'
+    - name: Build and test (3.12)
       if: |
         github.event_name == 'push' ||
         github.event_name == 'pull_request' ||

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Unreleased
 
 * Make pytket-qir an automatic dependency.
 * Update pytket-qir version requirement to 0.5.
-* Update pytket_pecos version requirement to 0.1.14.
+* Update pytket_pecos version requirement to 0.1.15.
 
 0.29.0 (January 2024)
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "pyjwt ~= 2.4",
         "msal ~= 1.18",
     ],
-    extras_require={"pecos": ["pytket-pecos ~= 0.1.14"]},
+    extras_require={"pecos": ["pytket-pecos ~= 0.1.15"]},
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -2,5 +2,5 @@ pytest
 pytest-timeout
 hypothesis
 requests_mock
-llvmlite ~= 0.41.1
+llvmlite ~= 0.42.0
 pytest-rerunfailures


### PR DESCRIPTION
# Description

This ensures the latest version of quantum-pecos (0.5.0.dev8).

Also update the version of llvmlite used in tests. This enables testing with Python 3.12 and closes #327 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
