### PR TITLE
Add support for TK2 gate

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Update pytket_pecos version requirement to 0.1.18.
+* Support TK2 as native gate.
 
 0.30.0 (February 2024)
 ----------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -77,10 +77,10 @@ The passes applied by different levels of optimisation are specified in the tabl
      - `SynthesiseTket <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.SynthesiseTket>`_
      - `FullPeepholeOptimise [3] <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.FullPeepholeOptimise>`_
    * - `FlattenRelabelRegistersPass <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.FlattenRelabelRegistersPass>`_
-     - `NormaliseTK2  <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.NormaliseTK2>`_
+     - `NormaliseTK2 [5]  <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.NormaliseTK2>`_
      - `NormaliseTK2  <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.NormaliseTK2>`_
    * -
-     - `DecomposeTK2 <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeTK2>`_
+     - `DecomposeTK2 [5] <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeTK2>`_
      - `DecomposeTK2 <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeTK2>`_
    * -
      - self.rebase_pass [2]
@@ -109,6 +109,8 @@ The passes applied by different levels of optimisation are specified in the tabl
 * [3] ``FullPeepholeOptimise`` has the argument ``target_2qb_gate=OpType.TK2``.
 
 * [4] ``auto_squash_pass`` has arguments ``auto_squash_pass({OpType.PhasedX, OpType.Rz})``
+
+* [5] Omitted if the target two-qubit gate is ``OpType.TK2``.
 
 .. note::   If ``optimisation_level = 0`` the device constraints are solved but no additional optimisation is applied. Setting ``optimisation_level = 1`` applies some light optimisations to the circuit. More intensive optimisation is applied by level 2 at the expense of increased runtime.
 .. note::   The pass ``ZZPhaseToRz`` is left out of ``optimisation_level=2`` as the passes applied by ``FullPeepholeOptimise`` will already cover these optimisations.

--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -525,7 +525,7 @@ class QuantinuumAPIOffline:
                 {
                     "name": "H1-1",
                     "n_qubits": 20,
-                    "gateset": ["RZZ", "Riswap", "TK2"],
+                    "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
                     "n_classical_registers": 120,
                     "n_shots": 10000,
                     "system_type": "hardware",
@@ -537,7 +537,7 @@ class QuantinuumAPIOffline:
                 {
                     "name": "H2-1",
                     "n_qubits": 32,
-                    "gateset": ["RZZ", "Riswap", "TK2"],
+                    "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
                     "n_classical_registers": 120,
                     "n_shots": 10000,
                     "system_type": "hardware",

--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -515,7 +515,7 @@ class QuantinuumAPIOffline:
             {
             "name": "H1-1",
             "n_qubits": 20,
-            "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+            "gateset": ["RZZ", "Riswap", "TK2"],
             "n_shots": 10000,
             "batching": True,
             }
@@ -525,7 +525,7 @@ class QuantinuumAPIOffline:
                 {
                     "name": "H1-1",
                     "n_qubits": 20,
-                    "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+                    "gateset": ["RZZ", "Riswap", "TK2"],
                     "n_classical_registers": 120,
                     "n_shots": 10000,
                     "system_type": "hardware",
@@ -537,7 +537,7 @@ class QuantinuumAPIOffline:
                 {
                     "name": "H2-1",
                     "n_qubits": 32,
-                    "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+                    "gateset": ["RZZ", "Riswap", "TK2"],
                     "n_classical_registers": 120,
                     "n_shots": 10000,
                     "system_type": "hardware",

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -518,6 +518,7 @@ class QuantinuumBackend(Backend):
         ]
         squash = auto_squash_pass({OpType.PhasedX, OpType.Rz})
         target_2qb_gate = self.compilation_config.target_2qb_gate
+        assert target_2qb_gate is not None
         # use default (perfect fidelities) for supported gates
         fidelities: Dict[str, Any] = {}
         if target_2qb_gate == OpType.TK2:

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -115,7 +115,7 @@ def _default_2q_gate(device_name: str) -> OpType:
 
 def _get_gateset(gates: List[str]) -> Set[OpType]:
     gs = _GATE_SET.copy()
-    if "Rxxyyzz" in gates:
+    if "TK2" in gates:
         gs.add(OpType.TK2)
     return gs
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -88,11 +88,7 @@ _STATUS_MAP = {
     "canceled": StatusEnum.CANCELLED,
 }
 
-_GATE_SET = {
-    OpType.Rz,
-    OpType.PhasedX,
-    OpType.ZZMax,
-    OpType.ZZPhase,
+_ADDITIONAL_GATES = {
     OpType.Reset,
     OpType.Measure,
     OpType.Barrier,
@@ -106,6 +102,18 @@ _GATE_SET = {
     OpType.WASM,
 }
 
+_GATE_MAP = {
+    "Rxxyyzz": OpType.TK2,
+    "Rz": OpType.Rz,
+    "RZZ": OpType.ZZPhase,
+    "TK2": OpType.TK2,
+    "U1q": OpType.PhasedX,
+    "ZZ": OpType.ZZMax,
+}
+
+_ALL_GATES = _ADDITIONAL_GATES.copy()
+_ALL_GATES.update(_GATE_MAP.values())
+
 
 def _default_2q_gate(device_name: str) -> OpType:
     # If we change this, we should update the main documentation page and highlight it
@@ -114,9 +122,12 @@ def _default_2q_gate(device_name: str) -> OpType:
 
 
 def _get_gateset(gates: List[str]) -> Set[OpType]:
-    gs = _GATE_SET.copy()
-    if "TK2" in gates:
-        gs.add(OpType.TK2)
+    gs = _ADDITIONAL_GATES.copy()
+    for gate in gates:
+        if gate not in _GATE_MAP:
+            warnings.warn(f"Gate {gate} not recognized.")
+        else:
+            gs.add(_GATE_MAP[gate])
     return gs
 
 
@@ -442,7 +453,7 @@ class QuantinuumBackend(Backend):
     @property
     def _gate_set(self) -> Set[OpType]:
         return (
-            _GATE_SET
+            _ALL_GATES
             if self._MACHINE_DEBUG
             else cast(BackendInfo, self.backend_info).gate_set
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H1-1SC",
             "n_qubits": 20,
-            "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+            "gateset": ["RZZ", "Riswap", "TK2"],
             "n_classical_registers": 120,
             "n_shots": 10000,
             "system_type": "syntax checker",
@@ -139,7 +139,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H1-1E",
             "n_qubits": 20,
-            "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+            "gateset": ["RZZ", "Riswap", "TK2"],
             "n_classical_registers": 120,
             "n_shots": 10000,
             "system_type": "emulator",
@@ -149,7 +149,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H1-1",
             "n_qubits": 20,
-            "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+            "gateset": ["RZZ", "Riswap", "TK2"],
             "n_classical_registers": 120,
             "n_shots": 10000,
             "system_type": "hardware",
@@ -161,7 +161,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H2-1E",
             "n_qubits": 32,
-            "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+            "gateset": ["RZZ", "Riswap", "TK2"],
             "n_classical_registers": 50,
             "n_shots": 10000,
             "system_type": "emulator",
@@ -171,7 +171,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H2-1",
             "n_qubits": 32,
-            "gateset": ["RZZ", "Riswap", "Rxxyyzz"],
+            "gateset": ["RZZ", "Riswap", "TK2"],
             "n_classical_registers": 50,
             "n_shots": 10000,
             "system_type": "hardware",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def mock_machine_info() -> Dict[str, Any]:
     return {
         "name": "H9-27",
         "n_qubits": 20,
-        "gateset": [],
+        "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
         "n_classical_registers": 120,
         "n_shots": 10000,
         "system_type": "hardware",
@@ -130,7 +130,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H1-1SC",
             "n_qubits": 20,
-            "gateset": ["RZZ", "Riswap", "TK2"],
+            "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
             "n_classical_registers": 120,
             "n_shots": 10000,
             "system_type": "syntax checker",
@@ -139,7 +139,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H1-1E",
             "n_qubits": 20,
-            "gateset": ["RZZ", "Riswap", "TK2"],
+            "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
             "n_classical_registers": 120,
             "n_shots": 10000,
             "system_type": "emulator",
@@ -149,7 +149,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H1-1",
             "n_qubits": 20,
-            "gateset": ["RZZ", "Riswap", "TK2"],
+            "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
             "n_classical_registers": 120,
             "n_shots": 10000,
             "system_type": "hardware",
@@ -161,7 +161,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H2-1E",
             "n_qubits": 32,
-            "gateset": ["RZZ", "Riswap", "TK2"],
+            "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
             "n_classical_registers": 50,
             "n_shots": 10000,
             "system_type": "emulator",
@@ -171,7 +171,7 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
         {
             "name": "H2-1",
             "n_qubits": 32,
-            "gateset": ["RZZ", "Riswap", "TK2"],
+            "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
             "n_classical_registers": 50,
             "n_shots": 10000,
             "system_type": "hardware",
@@ -180,8 +180,18 @@ def sample_machine_infos() -> List[Dict[str, Any]]:
             "batching": True,
             "wasm": True,
         },
-        {"name": "H1", "n_qubits": 20, "system_type": "hardware"},
-        {"name": "H2", "n_qubits": 32, "system_type": "hardware"},
+        {
+            "name": "H1",
+            "n_qubits": 20,
+            "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
+            "system_type": "hardware",
+        },
+        {
+            "name": "H2",
+            "n_qubits": 32,
+            "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
+            "system_type": "hardware",
+        },
     ]
 
 

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -913,8 +913,9 @@ def test_allow_2q_gate_rebase(authenticated_quum_backend: QuantinuumBackend) -> 
     [{"device_name": "H1-1SC"}],  # type: ignore
     indirect=True,
 )
+@pytest.mark.parametrize("language", [Language.QASM, Language.QIR])
 @pytest.mark.timeout(120)
-def test_tk2(authenticated_quum_backend: QuantinuumBackend) -> None:
+def test_tk2(authenticated_quum_backend: QuantinuumBackend, language: Language) -> None:
     c0 = (
         Circuit(2)
         .XXPhase(0.1, 0, 1)
@@ -925,7 +926,7 @@ def test_tk2(authenticated_quum_backend: QuantinuumBackend) -> None:
     b = authenticated_quum_backend
     b.set_compilation_config_target_2qb_gate(OpType.TK2)
     c = b.get_compiled_circuit(c0, 2)
-    h = b.process_circuit(c, n_shots=1)
+    h = b.process_circuit(c, n_shots=1, language=language)
     r = b.get_result(h)
     shots = r.get_shots()
     assert len(shots) == 1

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -908,6 +908,31 @@ def test_allow_2q_gate_rebase(authenticated_quum_backend: QuantinuumBackend) -> 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
+    "authenticated_quum_backend",
+    [{"device_name": name} for name in pytest.ALL_SYNTAX_CHECKER_NAMES],  # type: ignore
+    indirect=True,
+)
+@pytest.mark.timeout(120)
+def test_tk2(authenticated_quum_backend: QuantinuumBackend) -> None:
+    c0 = (
+        Circuit(2)
+        .XXPhase(0.1, 0, 1)
+        .YYPhase(0.2, 0, 1)
+        .ZZPhase(0.3, 0, 1)
+        .measure_all()
+    )
+    b = authenticated_quum_backend
+    b.set_compilation_config_target_2qb_gate(OpType.TK2)
+    c = b.get_compiled_circuit(c0, 2)
+    h = b.process_circuit(c, n_shots=1)
+    r = b.get_result(h)
+    shots = r.get_shots()
+    assert len(shots) == 1
+    assert len(shots[0]) == 2
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.parametrize(
     "authenticated_quum_backend", [{"device_name": "H1-1SC"}], indirect=True
 )
 @pytest.mark.timeout(120)

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -50,11 +50,7 @@ from pytket.extensions.quantinuum import (
     Language,
     prune_shots_detected_as_leaky,
 )
-from pytket.extensions.quantinuum.backends.quantinuum import (
-    GetResultFailed,
-    _GATE_SET,
-    # NoSyntaxChecker,
-)
+from pytket.extensions.quantinuum.backends.quantinuum import GetResultFailed, _ALL_GATES
 from pytket.extensions.quantinuum.backends.api_wrappers import (
     QuantinuumAPIError,
     QuantinuumAPI,
@@ -271,7 +267,7 @@ def circuits(
     total_qubits = draw(n_qubits)
     circuit = Circuit(total_qubits, total_qubits)
     for _ in range(draw(depth)):
-        gate = draw(st.sampled_from(list(_GATE_SET)))
+        gate = draw(st.sampled_from(list(_ALL_GATES)))
         control = draw(st.integers(min_value=0, max_value=total_qubits - 1))
         if gate == OpType.ZZMax:
             target = draw(

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -910,7 +910,7 @@ def test_allow_2q_gate_rebase(authenticated_quum_backend: QuantinuumBackend) -> 
 @pytest.mark.parametrize(
     "authenticated_quum_backend",
     # This fails on H2-1SC with QASM.
-    [{"device_name": "H1-1SC"}],  # type: ignore
+    [{"device_name": "H1-1SC"}],
     indirect=True,
 )
 @pytest.mark.parametrize("language", [Language.QASM, Language.QIR])
@@ -926,7 +926,7 @@ def test_tk2(authenticated_quum_backend: QuantinuumBackend, language: Language) 
     b = authenticated_quum_backend
     b.set_compilation_config_target_2qb_gate(OpType.TK2)
     c = b.get_compiled_circuit(c0, 2)
-    h = b.process_circuit(c, n_shots=1, language=language)
+    h = b.process_circuit(c, n_shots=1, language=language)  # type: ignore
     r = b.get_result(h)
     shots = r.get_shots()
     assert len(shots) == 1

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -909,7 +909,8 @@ def test_allow_2q_gate_rebase(authenticated_quum_backend: QuantinuumBackend) -> 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
     "authenticated_quum_backend",
-    [{"device_name": name} for name in pytest.ALL_SYNTAX_CHECKER_NAMES],  # type: ignore
+    # This fails on H2-1SC with QASM.
+    [{"device_name": "H1-1SC"}],  # type: ignore
     indirect=True,
 )
 @pytest.mark.timeout(120)

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -611,7 +611,8 @@ def test_retrieve_available_devices(
     )
     assert len(backend_infos) > 0
     assert all(
-        OpType.ZZPhase in backend_info.gate_set for backend_info in backend_infos
+        {OpType.TK2, OpType.ZZMax, OpType.ZZPhase} & backend_info.gate_set
+        for backend_info in backend_infos
     )
 
 


### PR DESCRIPTION
# Description

Previously we were looking only for "Rxxyyzz" as the gate name, not "TK2".

Also improve the default compilation passes when targeting this gate.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
