### PR TITLE
Set classical register width based on qubit count

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -371,6 +371,7 @@ class QuantinuumBackend(Backend):
             dct1["system_type"] = "local_emulator"
             dct1.pop("emulator", None)
             dct1["batching"] = False
+        dct1["cl_reg_width"] = 32 if n_qubits <= 32 else 64
         return BackendInfo(
             name=cls.__name__,
             device_name=name + "LE" if local_emulator else name,
@@ -880,7 +881,13 @@ class QuantinuumBackend(Backend):
             else:
                 results_selection = []
                 if language == Language.QASM:
-                    quantinuum_circ = circuit_to_qasm_str(c0, header="hqslib1")
+                    quantinuum_circ = circuit_to_qasm_str(
+                        c0,
+                        header="hqslib1",
+                        maxwidth=self.backend_info.misc["cl_reg_width"]
+                        if self.backend_info
+                        else 32,
+                    )
                     used_scratch_regs = _used_scratch_registers(quantinuum_circ)
                     for name, count in Counter(
                         bit.reg_name

--- a/tests/unit/api1_test.py
+++ b/tests/unit/api1_test.py
@@ -498,6 +498,7 @@ def test_available_devices(
         "syntax_checker": "H9-27SC",
         "batching": True,
         "wasm": True,
+        "cl_reg_width": 32,
     }
     assert backinfo0.name == "QuantinuumBackend"
 
@@ -518,6 +519,7 @@ def test_available_devices(
             "syntax_checker": "H9-27SC",
             "batching": False,
             "wasm": True,
+            "cl_reg_width": 32,
         }
         assert backinfo1.name == "QuantinuumBackend"
 


### PR DESCRIPTION
# Description

Since we don't (yet) have this information in the API, hard-code it to 32 if the number of qubits is <= 32 and 64 otherwise.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
