### PR TITLE
Remove `no_opt` and `allow_2q_gate_rebase` options

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Remove ``no_opt`` and ``allow_2q_gate_rebase`` options to
+  ``process_circuits()`` and ``submit_program()``, and assume that the submitted
+  circuit is exactly what is desired to be run.
+
 0.31.0 (March 2024)
 -------------------
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -131,12 +131,6 @@ default. This may be overridden using the method
 ``QuantinuumBackend.set_compilation_config_target_2qb_gate()`` or by passing a
 ``QuantinuumBackendCompilationConfig`` when constructing the backend.
 
-If desired, backends may be allowed to rebase to a different two-qubit gate
-judged to have better fidelity before being run. The default is to run with the
-gate provided in the submitted circuit, but this behaviour may be overridden
-using the optional ``allow_2q_gate_rebase`` argument to ``process_circuit()``,
-``process_circuits()`` or ``submit_program()``.
-
 Device Predicates
 =================
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -794,6 +794,7 @@ information not available for emulators (E) or syntax checkers (SC)."
                 "noreduce": not allow_2q_gate_rebase,
                 "error-model": noisy_simulation,
                 "tket": dict(),
+                "tket-opt-level": None,
             },
         }
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -741,7 +741,6 @@ information not available for emulators (E) or syntax checkers (SC)."
         group: Optional[str] = None,
         wasm_file_handler: Optional[WasmFileHandler] = None,
         pytket_pass: Optional[BasePass] = None,
-        allow_2q_gate_rebase: bool = False,
         options: Optional[Dict[str, Any]] = None,
         request_options: Optional[Dict[str, Any]] = None,
         results_selection: Optional[List[Tuple[str, int]]] = None,
@@ -758,8 +757,6 @@ information not available for emulators (E) or syntax checkers (SC)."
           tracking. Overrides the instance variable `group`, defaults to None
         :param wasm_file_handler: ``WasmFileHandler`` object for linked WASM
             module, defaults to None
-        :param allow_2q_gate_rebase: if true, allow rebasing of the two-qubit gates to
-           a higher-fidelity alternative gate at the discretion of the backend
         :param pytket_pass: ``pytket.passes.BasePass`` intended to be applied
            by the backend (beta feature, may be ignored), defaults to None
         :param options: Items to add to the "options" dictionary of the request body
@@ -789,7 +786,7 @@ information not available for emulators (E) or syntax checkers (SC)."
             "options": {
                 "simulator": self.simulator_type,
                 "no-opt": True,
-                "noreduce": not allow_2q_gate_rebase,
+                "noreduce": True,
                 "error-model": noisy_simulation,
                 "tket": dict(),
                 "tket-opt-level": None,
@@ -868,8 +865,6 @@ information not available for emulators (E) or syntax checkers (SC)."
         * `wasm_file_handler`: a ``WasmFileHandler`` object for linked WASM module.
         * `pytketpass`: a ``pytket.passes.BasePass`` intended to be applied
            by the backend (beta feature, may be ignored).
-        * `allow_2q_gate_rebase`: if true, allow rebasing of the two-qubit gates to a
-           higher-fidelity alternative gate at the discretion of the backend
         * `options`: items to add to the "options" dictionary of the request body, as a
           json-style dictionary (in addition to any that were set in the backend
           constructor)
@@ -913,8 +908,6 @@ information not available for emulators (E) or syntax checkers (SC)."
         wasm_fh = cast(Optional[WasmFileHandler], kwargs.get("wasm_file_handler"))
 
         pytket_pass = cast(Optional[BasePass], kwargs.get("pytketpass"))
-
-        allow_2q_gate_rebase = cast(bool, kwargs.get("allow_2q_gate_rebase", False))
 
         language = cast(Language, kwargs.get("language", Language.QASM))
 
@@ -1018,7 +1011,6 @@ information not available for emulators (E) or syntax checkers (SC)."
                         group=group,
                         wasm_file_handler=wasm_fh,
                         pytket_pass=pytket_pass,
-                        allow_2q_gate_rebase=allow_2q_gate_rebase,
                         options=cast(Dict[str, Any], kwargs.get("options", {})),
                         request_options=cast(
                             Dict[str, Any], kwargs.get("request_options", {})

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -741,7 +741,6 @@ information not available for emulators (E) or syntax checkers (SC)."
         group: Optional[str] = None,
         wasm_file_handler: Optional[WasmFileHandler] = None,
         pytket_pass: Optional[BasePass] = None,
-        no_opt: bool = False,
         allow_2q_gate_rebase: bool = False,
         options: Optional[Dict[str, Any]] = None,
         request_options: Optional[Dict[str, Any]] = None,
@@ -759,7 +758,6 @@ information not available for emulators (E) or syntax checkers (SC)."
           tracking. Overrides the instance variable `group`, defaults to None
         :param wasm_file_handler: ``WasmFileHandler`` object for linked WASM
             module, defaults to None
-        :param no_opt: if true, requests that the backend perform no optimizations
         :param allow_2q_gate_rebase: if true, allow rebasing of the two-qubit gates to
            a higher-fidelity alternative gate at the discretion of the backend
         :param pytket_pass: ``pytket.passes.BasePass`` intended to be applied
@@ -790,7 +788,7 @@ information not available for emulators (E) or syntax checkers (SC)."
             "priority": "normal",
             "options": {
                 "simulator": self.simulator_type,
-                "no-opt": no_opt,
+                "no-opt": True,
                 "noreduce": not allow_2q_gate_rebase,
                 "error-model": noisy_simulation,
                 "tket": dict(),
@@ -870,7 +868,6 @@ information not available for emulators (E) or syntax checkers (SC)."
         * `wasm_file_handler`: a ``WasmFileHandler`` object for linked WASM module.
         * `pytketpass`: a ``pytket.passes.BasePass`` intended to be applied
            by the backend (beta feature, may be ignored).
-        * `no_opt`: if true, requests that the backend perform no optimizations
         * `allow_2q_gate_rebase`: if true, allow rebasing of the two-qubit gates to a
            higher-fidelity alternative gate at the discretion of the backend
         * `options`: items to add to the "options" dictionary of the request body, as a
@@ -916,8 +913,6 @@ information not available for emulators (E) or syntax checkers (SC)."
         wasm_fh = cast(Optional[WasmFileHandler], kwargs.get("wasm_file_handler"))
 
         pytket_pass = cast(Optional[BasePass], kwargs.get("pytketpass"))
-
-        no_opt = cast(bool, kwargs.get("no_opt", False))
 
         allow_2q_gate_rebase = cast(bool, kwargs.get("allow_2q_gate_rebase", False))
 
@@ -1023,7 +1018,6 @@ information not available for emulators (E) or syntax checkers (SC)."
                         group=group,
                         wasm_file_handler=wasm_fh,
                         pytket_pass=pytket_pass,
-                        no_opt=no_opt,
                         allow_2q_gate_rebase=allow_2q_gate_rebase,
                         options=cast(Dict[str, Any], kwargs.get("options", {})),
                         request_options=cast(

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -333,7 +333,7 @@ def test_cost_estimate(
         # All other real hardware backends should have the
         # "syntax_checker" misc property set, so there should be no
         # need of providing it explicitly.
-        estimate = b.cost(c, n_shots, no_opt=False)
+        estimate = b.cost(c, n_shots)
         if estimate is None:
             pytest.skip("API is flaky, sometimes returns None unexpectedly.")
         assert isinstance(estimate, float)
@@ -903,27 +903,6 @@ def test_options(
     b = authenticated_quum_backend_qa
     c = b.get_compiled_circuit(c0, 0)
     h = b.process_circuits([c], n_shots=1, options={"ignoreme": 0}, language=language)  # type: ignore
-    r = b.get_results(h)[0]
-    shots = r.get_shots()
-    assert len(shots) == 1
-    assert len(shots[0]) == 1
-
-
-@pytest.mark.skipif(skip_remote_tests, reason=REASON)
-@pytest.mark.parametrize(
-    "authenticated_quum_backend_qa",
-    [{"device_name": name} for name in pytest.ALL_SYNTAX_CHECKER_NAMES],  # type: ignore
-    indirect=True,
-)
-@pytest.mark.parametrize("language", [Language.QASM, Language.QIR])
-@pytest.mark.timeout(120)
-def test_no_opt(
-    authenticated_quum_backend_qa: QuantinuumBackend, language: Language
-) -> None:
-    c0 = Circuit(1).H(0).measure_all()
-    b = authenticated_quum_backend_qa
-    c = b.get_compiled_circuit(c0, 0)
-    h = b.process_circuits([c], n_shots=1, no_opt=True, language=language)  # type: ignore
     r = b.get_results(h)[0]
     shots = r.get_shots()
     assert len(shots) == 1

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -915,25 +915,6 @@ def test_options(
     [{"device_name": name} for name in pytest.ALL_SYNTAX_CHECKER_NAMES],  # type: ignore
     indirect=True,
 )
-@pytest.mark.timeout(120)
-def test_allow_2q_gate_rebase(authenticated_quum_backend_qa: QuantinuumBackend) -> None:
-    c0 = Circuit(2).H(0).CX(0, 1).measure_all()
-    b = authenticated_quum_backend_qa
-    b.set_compilation_config_target_2qb_gate(OpType.ZZMax)
-    c = b.get_compiled_circuit(c0, 0)
-    h = b.process_circuits([c], n_shots=1, allow_2q_gate_rebase=True)
-    r = b.get_results(h)[0]
-    shots = r.get_shots()
-    assert len(shots) == 1
-    assert len(shots[0]) == 2
-
-
-@pytest.mark.skipif(skip_remote_tests, reason=REASON)
-@pytest.mark.parametrize(
-    "authenticated_quum_backend_qa",
-    [{"device_name": name} for name in pytest.ALL_SYNTAX_CHECKER_NAMES],  # type: ignore
-    indirect=True,
-)
 @pytest.mark.parametrize("language", [Language.QASM, Language.QIR])
 @pytest.mark.timeout(120)
 def test_tk2(


### PR DESCRIPTION
# Description

Set both `no-opt` and `noreduce` to `True` to prevent any changes to the submitted circuit. It is assumed that the submitted circuit is what is desired to be run.

(It's still possible for these options to be overridden by providing an `options` dictionary to `process_circuits()` or `submit_program()`, but this is very much opt-in for those who know what they're doing.)

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
