### PR TITLE
feat: Offline device list constant

### DIFF
--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -517,6 +517,34 @@ class QuantinuumAPI:
         return jr
 
 
+OFFLINE_MACHINE_LIST = [
+    {
+        "name": "H1-1",
+        "n_qubits": 20,
+        "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
+        "n_classical_registers": 120,
+        "n_shots": 10000,
+        "system_type": "hardware",
+        "emulator": "H1-1E",
+        "syntax_checker": "H1-1SC",
+        "batching": True,
+        "wasm": True,
+    },
+    {
+        "name": "H2-1",
+        "n_qubits": 32,
+        "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
+        "n_classical_registers": 120,
+        "n_shots": 10000,
+        "system_type": "hardware",
+        "emulator": "H2-1E",
+        "syntax_checker": "H2-1SC",
+        "batching": True,
+        "wasm": True,
+    },
+]
+
+
 class QuantinuumAPIOffline:
     """
     Offline copy of the interface to the Quantinuum remote API.
@@ -543,32 +571,7 @@ class QuantinuumAPIOffline:
             }
         """
         if machine_list == None:
-            machine_list = [
-                {
-                    "name": "H1-1",
-                    "n_qubits": 20,
-                    "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
-                    "n_classical_registers": 120,
-                    "n_shots": 10000,
-                    "system_type": "hardware",
-                    "emulator": "H1-1E",
-                    "syntax_checker": "H1-1SC",
-                    "batching": True,
-                    "wasm": True,
-                },
-                {
-                    "name": "H2-1",
-                    "n_qubits": 32,
-                    "gateset": ["Rz", "RZZ", "TK2", "U1q", "ZZ"],
-                    "n_classical_registers": 120,
-                    "n_shots": 10000,
-                    "system_type": "hardware",
-                    "emulator": "H2-1E",
-                    "syntax_checker": "H2-1SC",
-                    "batching": True,
-                    "wasm": True,
-                },
-            ]
+            machine_list = OFFLINE_MACHINE_LIST
         self.provider = ""
         self.url = ""
         self.online = False


### PR DESCRIPTION
When using this library, it is sometimes useful to be able to define a custom offline API implementation with different devices which includes the devices of the base implementation. This commit splits those devices out into a constant that can be referred to by other code.

# Description

Please summarise the changes.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
