### PR TITLE
Reuse Circuit Qubits when adding Leakage Detection

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Update pytket_pecos version requirement to 0.1.25.
+* Update Leakage Detection to reuse circuit qubits.
 
 0.33.0 (April 2024)
 -------------------


### PR DESCRIPTION
# Description

Currently if an input Circuit has the same number of qubits as the Device then Leakage Detection throws an error on the premise that there are no spare qubits. With this PR, leakage detection now reuses measured circuit qubits with no further gates to perform leakage detection with.

# Related issues

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
