### PR TITLE
Update to pytket-pecos 0.1.27

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-* Update pytket_pecos version requirement to 0.1.26.
+* Update pytket_pecos version requirement to 0.1.27.
 * Update Leakage Detection to reuse circuit qubits.
 * Update pytket version requirement to 1.28.
 * Update pytket-qir version requirement to 0.11.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "msal ~= 1.18",
     ],
     extras_require={
-        "pecos": ["pytket-pecos ~= 0.1.26"],
+        "pecos": ["pytket-pecos ~= 0.1.27"],
         "calendar": ["matplotlib >= 3.8.3,< 3.10.0", "pandas ~= 2.2.1"],
     },
     classifiers=[


### PR DESCRIPTION
Test failure is #443 .