### PR TITLE
Temporarily restrict maximum classical register width to 32

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Restrict classical registers to a maximum size of 32 (until pytket can
+  support larger values).
+
 0.34.0 (June 2024)
 ------------------
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -395,7 +395,6 @@ class QuantinuumBackend(Backend):
             dct1["system_type"] = "local_emulator"
             dct1.pop("emulator", None)
             dct1["batching"] = False
-        dct1["cl_reg_width"] = 32 if n_qubits <= 32 else 64
         return BackendInfo(
             name=cls.__name__,
             device_name=name + "LE" if local_emulator else name,
@@ -1026,9 +1025,9 @@ class QuantinuumBackend(Backend):
                     quantinuum_circ = circuit_to_qasm_str(
                         c0,
                         header="hqslib1",
-                        maxwidth=self.backend_info.misc["cl_reg_width"]
-                        if self.backend_info
-                        else 32,
+                        maxwidth=32,
+                        # TODO Get maxwidth from self.backend_info once
+                        # https://github.com/CQCL/tket/issues/1445 fixed in pytket
                     )
                     used_scratch_regs = _used_scratch_registers(quantinuum_circ)
                     for name, count in Counter(

--- a/tests/unit/api1_test.py
+++ b/tests/unit/api1_test.py
@@ -498,7 +498,6 @@ def test_available_devices(
         "syntax_checker": "H9-27SC",
         "batching": True,
         "wasm": True,
-        "cl_reg_width": 32,
     }
     assert backinfo0.name == "QuantinuumBackend"
 
@@ -519,7 +518,6 @@ def test_available_devices(
             "syntax_checker": "H9-27SC",
             "batching": False,
             "wasm": True,
-            "cl_reg_width": 32,
         }
         assert backinfo1.name == "QuantinuumBackend"
 


### PR DESCRIPTION
# Description

Until https://github.com/CQCL/tket/issues/1445 is fixed in pytket.

# Related issues

Works around #451 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
