### PR TITLE
Update version and changelog for 0.35.0 release.

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.34.1"
+__extension_version__ = "0.35.0"
 __extension_name__ = "pytket-quantinuum"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 ~~~~~~~~~
 
-Unreleased
-----------
+0.35.0 (June 2024)
+------------------
 
 * Update pytket version requirement to 1.29.
 * Update pytket_pecos version requirement to 0.1.28.


### PR DESCRIPTION
The main point of this release is to require (via pytket-pecos version bump) a version of pytket-phir (0.7.3) that will handle 64-bit classical operations, which will be necessary after https://github.com/CQCL/tket/pull/1456 finds its way to a pytket release.