### PR TITLE
Don't use partial results.

### DIFF
--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -427,6 +427,7 @@ class QuantinuumAPI:
                         "action": "OpenConnection",
                         "task_token": task_token,
                         "executionArn": execution_arn,
+                        "partial": False,
                     }
                     await websocket.send(json.dumps(body))
                     while True:


### PR DESCRIPTION
This should cause no change to behaviour, but ensures that when partial results retrieval becomes the default we are not surprised by it.
