### PR TITLE
[fix] update number of bits in result to fix test

### DIFF
--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -1044,7 +1044,7 @@ def test_qir_submission_mz_to_reg_qa(
     h = b.submit_program(Language.QIR, b64encode(ir).decode("utf-8"), n_shots=10)
     r = b.get_result(h)
     assert len(r.get_shots()) == 10
-    assert len(r.get_bitlist()) == 128
+    assert len(r.get_bitlist()) == 20
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)


### PR DESCRIPTION
# Description

Fixes https://github.com/CQCL/pytket-quantinuum/issues/492

The QIR submitted by this testcase contains four cregs, each containing 5 bits. This is an expected change in how the result is reported.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
