### PR TITLE
feat: Use float for ZZPhase in DecomposeTK2

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -669,7 +669,7 @@ class QuantinuumBackend(Backend):
         elif target_2qb_gate == OpType.ZZPhase:
             decomposition_passes = [
                 NormaliseTK2(),
-                DecomposeTK2(ZZPhase_fidelity=lambda x: 1.0),
+                DecomposeTK2(ZZPhase_fidelity=1.0),
             ]
         elif target_2qb_gate == OpType.ZZMax:
             decomposition_passes = [NormaliseTK2(), DecomposeTK2(ZZMax_fidelity=1.0)]

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket >= 1.31.0",
+        "pytket >= 1.33.0",
         "pytket-qir >= 0.12.0",
         "requests >= 2.2",
         "types-requests",


### PR DESCRIPTION
# Description

Replaces the use of a lambda with a constant value with a constant float. This change will make the default serialization pass for the backend serializable.

# Related issues

None

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
