### PR TITLE
feat: Lazily load 2qb gate

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -629,16 +629,16 @@ class QuantinuumBackend(Backend):
     @cached_property
     def default_two_qubit_gate(self) -> OpType:
         """Returns the default two-qubit gate for the device."""
-        self._default_2q_gate = _default_2q_gate(self._device_name)
+        default_2q_gate = _default_2q_gate(self._device_name)
 
-        if self._default_2q_gate in self.two_qubit_gate_set:
+        if default_2q_gate in self.two_qubit_gate_set:
             pass
         elif len(self.two_qubit_gate_set) > 0:
-            self._default_2q_gate = list(self.two_qubit_gate_set)[0]
+            default_2q_gate = list(self.two_qubit_gate_set)[0]
         else:
             raise ValueError("The device is not supporting any two qubit gates")
 
-        return self._default_2q_gate
+        return default_2q_gate
 
     @cached_property
     def two_qubit_gate_set(self) -> set[OpType]:

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -330,7 +330,7 @@ class QuantinuumBackend(Backend):
         has not already been set.
         """
         if self._compilation_config.target_2qb_gate is None:
-            self._compilation_config.target_2qb_gate = self._default_2q_gate
+            self._compilation_config.target_2qb_gate = self.default_two_qubit_gate
         return self._compilation_config
 
     def get_compilation_config(self) -> QuantinuumBackendCompilationConfig:

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -325,7 +325,7 @@ class QuantinuumBackend(Backend):
     @property
     def compilation_config(self) -> QuantinuumBackendCompilationConfig:
         """The current compilation configuration for the Backend.
-        
+
         Accessing this property will set the target_2qb_gate if it
         has not already been set.
         """

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -24,7 +24,7 @@ from collections.abc import Sequence
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from functools import cache
+from functools import cache, cached_property
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from uuid import uuid1
@@ -317,23 +317,21 @@ class QuantinuumBackend(Backend):
             _LocalEmulatorConfiguration,
         ] = dict()
 
-        self._default_2q_gate = _default_2q_gate(device_name)
-
-        if self._default_2q_gate in self.two_qubit_gate_set:
-            pass
-        elif len(self.two_qubit_gate_set) > 0:
-            self._default_2q_gate = list(self.two_qubit_gate_set)[0]
-        else:
-            raise ValueError("The device is not supporting any two qubit gates")
-
         if compilation_config is None:
-            self.compilation_config = QuantinuumBackendCompilationConfig(
-                allow_implicit_swaps=True, target_2qb_gate=self._default_2q_gate
-            )
+            self._compilation_config = QuantinuumBackendCompilationConfig()
         else:
-            self.compilation_config = compilation_config
-            if self.compilation_config.target_2qb_gate is None:
-                self.compilation_config.target_2qb_gate = self._default_2q_gate
+            self._compilation_config = compilation_config
+
+    @property
+    def compilation_config(self) -> QuantinuumBackendCompilationConfig:
+        """The current compilation configuration for the Backend.
+        
+        Accessing this property will set the target_2qb_gate if it
+        has not already been set.
+        """
+        if self._compilation_config.target_2qb_gate is None:
+            self._compilation_config.target_2qb_gate = self._default_2q_gate
+        return self._compilation_config
 
     def get_compilation_config(self) -> QuantinuumBackendCompilationConfig:
         """Get the current compilation configuration."""
@@ -607,7 +605,7 @@ class QuantinuumBackend(Backend):
             self._backend_info = self._retrieve_backendinfo(self._device_name)
         return self._backend_info
 
-    @property
+    @cached_property
     def _gate_set(self) -> set[OpType]:
         return (
             _ALL_GATES
@@ -628,12 +626,21 @@ class QuantinuumBackend(Backend):
 
         return preds
 
-    @property
+    @cached_property
     def default_two_qubit_gate(self) -> OpType:
         """Returns the default two-qubit gate for the device."""
+        self._default_2q_gate = _default_2q_gate(self._device_name)
+
+        if self._default_2q_gate in self.two_qubit_gate_set:
+            pass
+        elif len(self.two_qubit_gate_set) > 0:
+            self._default_2q_gate = list(self.two_qubit_gate_set)[0]
+        else:
+            raise ValueError("The device is not supporting any two qubit gates")
+
         return self._default_2q_gate
 
-    @property
+    @cached_property
     def two_qubit_gate_set(self) -> set[OpType]:
         """Returns the set of supported two-qubit gates.
 

--- a/tests/unit/offline_backend_test.py
+++ b/tests/unit/offline_backend_test.py
@@ -154,8 +154,8 @@ def test_shots_bits_edgecases(n_shots, n_bits, language: Language) -> None:
 @pytest.mark.parametrize("device_name", pytest.ALL_DEVICE_NAMES)  # type: ignore
 def test_defaultapi_handler(device_name: str) -> None:
     """Test that the default API handler is used on backend construction."""
-    backend_1 = QuantinuumBackend(device_name, machine_debug=True)
-    backend_2 = QuantinuumBackend(device_name, machine_debug=True)
+    backend_1 = QuantinuumBackend(device_name)
+    backend_2 = QuantinuumBackend(device_name)
 
     assert backend_1.api_handler is backend_2.api_handler
 
@@ -166,12 +166,8 @@ def test_custom_api_handler(device_name: str) -> None:
     handler_1 = QuantinuumAPI()
     handler_2 = QuantinuumAPI()
 
-    backend_1 = QuantinuumBackend(
-        device_name, api_handler=handler_1, machine_debug=True
-    )
-    backend_2 = QuantinuumBackend(
-        device_name, api_handler=handler_2, machine_debug=True
-    )
+    backend_1 = QuantinuumBackend(device_name, api_handler=handler_1)
+    backend_2 = QuantinuumBackend(device_name, api_handler=handler_2)
 
     assert backend_1.api_handler is not backend_2.api_handler
     assert backend_1.api_handler._cred_store is not backend_2.api_handler._cred_store


### PR DESCRIPTION
# Description

Rather than fetching the 2qb gate of devices on backend construction, this commit changes the behavior of the backend to only fetch devices once the 2qb gate is requested and caches the value as a cached_property using a decorator. As a side effect it removes the need for the user to log in to construct a backend.

Changes to tests that were required due to the backend now requiring credentials to construct have been reverted.

# Related issues

Tangentially related to https://github.com/CQCL/pytket-quantinuum/issues/504

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
