### PR TITLE
Use QIR by default for program submission

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Use QIR by default for program submission.
+
 0.38.1 (October 2024)
 ---------------------
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -980,17 +980,7 @@ class QuantinuumBackend(Backend):
 
         pytket_pass = cast(Optional[BasePass], kwargs.get("pytketpass"))
 
-        language: Optional[Language] = cast(Language, kwargs.get("language"))
-
-        if language is None:
-            language = Language.QASM
-            warnings.warn(
-                "The circuit is currently submitted as QASM by default. \
-The default is going to change. If you want to continue to use QASM \
-please add `language=Language.QASM` as an argument to `process_circuits()` \
-or `process_circuit()` to ensure consistent behaviour. If you want to try \
-QIR, please add `language=Language.QIR`."
-            )
+        language: Language = cast(Language, kwargs.get("language", Language.QIR))
 
         handle_list = []
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1451,10 +1451,17 @@ jobid is {jobid}"
             raise ValueError(f"Device {backend._device_name} is not a syntax checker.")
 
         wasm_fh = cast(Optional[WasmFileHandler], kwargs.get("wasm_file_handler"))
+        language: Optional[Language] = cast(
+            Language, kwargs.get("language"), Language.QASM
+        )
 
         try:
             handle = backend.process_circuit(
-                circuit, n_shots, kwargs=kwargs, wasm_file_handler=wasm_fh
+                circuit,
+                n_shots,
+                kwargs=kwargs,
+                wasm_file_handler=wasm_fh,
+                language=language,
             )
         except DeviceNotAvailable as e:
             raise ValueError(

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1452,7 +1452,7 @@ jobid is {jobid}"
 
         wasm_fh = cast(Optional[WasmFileHandler], kwargs.get("wasm_file_handler"))
         language: Optional[Language] = cast(
-            Language, kwargs.get("language"), Language.QASM
+            Language, kwargs.get("language", Language.QASM)
         )
 
         try:

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1050,6 +1050,7 @@ QIR, please add `language=Language.QIR`."
                             else 32
                         ),
                     )
+
                     used_scratch_regs = _used_scratch_registers(quantinuum_circ)
                     for name, count in Counter(
                         bit.reg_name
@@ -1062,9 +1063,6 @@ QIR, please add `language=Language.QIR`."
                 else:
                     assert language == Language.QIR or language == Language.PQIR
                     profile = language == Language.PQIR
-                    for name, count in Counter(bit.reg_name for bit in c0.bits).items():
-                        for i in range(count):
-                            results_selection.append((name, i))
 
                     quantinuum_circ = b64encode(
                         cast(
@@ -1078,6 +1076,12 @@ QIR, please add `language=Language.QIR`."
                             ),
                         )
                     ).decode("utf-8")
+
+                    for name, count in Counter(
+                        bit.reg_name for bit in c0.bits if not _is_scratch(bit)
+                    ).items():
+                        for i in range(count):
+                            results_selection.append((name, i))
                 if self._MACHINE_DEBUG:
                     handle_list.append(
                         ResultHandle(
@@ -1446,8 +1450,12 @@ jobid is {jobid}"
         if backend.backend_info.get_misc("system_type") != "syntax checker":
             raise ValueError(f"Device {backend._device_name} is not a syntax checker.")
 
+        wasm_fh = cast(Optional[WasmFileHandler], kwargs.get("wasm_file_handler"))
+
         try:
-            handle = backend.process_circuit(circuit, n_shots, kwargs=kwargs)
+            handle = backend.process_circuit(
+                circuit, n_shots, kwargs=kwargs, wasm_file_handler=wasm_fh
+            )
         except DeviceNotAvailable as e:
             raise ValueError(
                 f"Cannot find syntax checker for device {self._device_name}. "

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -1106,12 +1106,22 @@ def test_old_handle(
     assert (r0.get_shots() == r1.get_shots()).all()
 
 
+@pytest.mark.parametrize(
+    "language",
+    [
+        Language.QASM,
+        Language.QIR,
+        Language.PQIR,
+    ],
+)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
     "authenticated_quum_backend_qa", [{"device_name": "H1-1SC"}], indirect=True
 )
 @pytest.mark.timeout(120)
-def test_scratch_removal(authenticated_quum_backend_qa: QuantinuumBackend) -> None:
+def test_scratch_removal(
+    authenticated_quum_backend_qa: QuantinuumBackend, language: Language
+) -> None:
     # https://github.com/CQCL/pytket-quantinuum/issues/213
     c = Circuit()
     qb0 = c.add_q_register("qb0", 3)
@@ -1136,12 +1146,11 @@ def test_scratch_removal(authenticated_quum_backend_qa: QuantinuumBackend) -> No
 
     b = authenticated_quum_backend_qa
     c1 = b.get_compiled_circuit(c, optimisation_level=1)
-    h = b.process_circuit(c1, n_shots=3)
+    h = b.process_circuit(c1, n_shots=3, language=language)
     r = b.get_result(h)
     shots = r.get_shots()
     assert len(shots) == 3
     assert all(len(shot) == 5 for shot in shots)
-
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -1152,6 +1152,7 @@ def test_scratch_removal(
     assert len(shots) == 3
     assert all(len(shot) == 5 for shot in shots)
 
+
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
     "authenticated_quum_backend_qa", [{"device_name": "H1-1E"}], indirect=True


### PR DESCRIPTION
Planned for release in early November. If we need to do a hotfix release before then, we may want to revert this change. But I'd like to merge it to `main` early to get maximal testing.