### PR TITLE
Update runners used on CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,7 +35,7 @@ jobs:
     name: Quantinuum - Build and test module
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-14', 'windows-2022']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     - name: Build and test (3.11) mypy
       shell: bash
       if: |
-        matrix.os == 'macos-12' &&
+        matrix.os == 'macos-14' &&
         (
           github.event_name == 'push' ||
           (
@@ -77,7 +77,7 @@ jobs:
         ./.github/workflows/build-test mypy
     - name: Build and test (3.11) nomypy
       if: |
-        matrix.os != 'macos-12' &&
+        matrix.os != 'macos-14' &&
         (
           github.event_name == 'push' ||
           (
@@ -95,7 +95,7 @@ jobs:
         ./.github/workflows/build-test nomypy
     - name: Build and test including integration (3.11) nomypy
       if: |
-        matrix.os == 'ubuntu-22.04' &&
+        matrix.os == 'ubuntu-24.04' &&
         (
           (
             github.event_name == 'push' &&
@@ -141,12 +141,12 @@ jobs:
     - name: Install poetry
       run: pip install poetry
     - name: Install docs dependencies
-      if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
+      if:  (matrix.os == 'ubuntu-24.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       run: |
           cd docs && bash ./install.sh
           for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
     - name: Build docs
-      if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
+      if:  (matrix.os == 'ubuntu-24.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20
       run: |
           cd docs && poetry run bash ./build-docs.sh
@@ -154,7 +154,7 @@ jobs:
   pecos_checks:
     name: Run local-emulator tests
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -176,7 +176,7 @@ jobs:
   qa_checks:
     name: Run backend tests with QA endpoint
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -199,7 +199,7 @@ jobs:
   calendar_visualisation_tests:
     name: Run calendar visualisation test
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -225,7 +225,7 @@ jobs:
   prod_checks:
     name: Run backend tests with QA and prod endpoint
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.ref_name, 'runci/prod/')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -261,7 +261,7 @@ jobs:
     name: Publish to pypi
     if: github.event_name == 'release'
     needs: quantinuum-checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Download all wheels
       # downloading all three files into the wheelhouse
@@ -286,7 +286,7 @@ jobs:
     name: Build docs
     if: github.event_name == 'release'
     needs: publish_to_pypi
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -18,7 +18,7 @@ env:
 jobs:
 
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       examples: ${{ steps.filter.outputs.examples }}
     steps:
@@ -42,7 +42,7 @@ jobs:
         github.event_name == 'pull_request' &&
         needs.changes.outputs.examples == 'true'
       )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   docs:
     name: build docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with: 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,11 +21,8 @@ jobs:
     - name: Install black and pylint
       run: pip install "black[jupyter]" pylint ruff
     - name: Check files are formatted with black
-      run: |
-        black --check .
+      run: black --check .
     - name: Run ruff
-      run: |
-        ruff check .        
+      run: ruff check .
     - name: Run pylint
-      run: |        
-        pylint */
+      run: pylint */

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   lint:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The `macos-12` runner is being removed soon; `macos-latest` is currently `macos-14`. Also update to `ubuntu-24.04` a.k.a. `ubuntu-latest` while we're here.

(Will update names of "required checks" after approval.)