### PR TITLE
Set number of qubits for leakage detection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 
 - Use QIR by default for program submission.
 - Update pytket-qir version requirement to 0.15.
+- Add new `kwarg` `n_leakage_detection_qubits` to `process_circuits()`
 
 ## 0.38.1 (October 2024)
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -965,7 +965,8 @@ class QuantinuumBackend(Backend):
             )
             if n_leakage_detection_qubits > self.backend_info.n_nodes:
                 raise ValueError(
-                    "Number of qubits specified for leakage detection is larger than the number of qubits on the device."
+                    "Number of qubits specified for leakage detection is larger than "
+                    "the number of qubits on the device."
                 )
             circuits = [
                 self.get_compiled_circuit(

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -960,8 +960,8 @@ class QuantinuumBackend(Backend):
         )
 
         if kwargs.get("leakage_detection", False):
-            n_device_nodes: int = cast(int, self.backend_info.n_nodes)
-            n_leakage_detection_qubits: int = kwargs.get(
+            n_device_nodes: int = cast(int, self.backend_info.n_nodes)  # type: ignore
+            n_leakage_detection_qubits: int = kwargs.get(  # type: ignore
                 "n_leakage_detection_qubits", n_device_nodes
             )
             if n_leakage_detection_qubits > n_device_nodes:
@@ -971,7 +971,7 @@ class QuantinuumBackend(Backend):
                 )
             circuits = [
                 self.get_compiled_circuit(
-                    get_detection_circuit(c, n_leakage_detection_qubits),  # type: ignore
+                    get_detection_circuit(c, n_leakage_detection_qubits),
                     optimisation_level=0,
                 )
                 for c in circuits

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -960,10 +960,11 @@ class QuantinuumBackend(Backend):
         )
 
         if kwargs.get("leakage_detection", False):
+            n_device_nodes: int = cast(int, self.backend_info.n_nodes)
             n_leakage_detection_qubits: int = kwargs.get(
-                "n_leakage_detection_qubits", self.backend_info.n_nodes
+                "n_leakage_detection_qubits", n_device_nodes
             )
-            if n_leakage_detection_qubits > self.backend_info.n_nodes:
+            if n_leakage_detection_qubits > n_device_nodes:
                 raise ValueError(
                     "Number of qubits specified for leakage detection is larger than "
                     "the number of qubits on the device."

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -516,7 +516,9 @@ def test_leakage_detection(
     c = Circuit(2, 2).H(0).CZ(0, 1).Measure(0, 0).Measure(1, 1)
 
     with pytest.raises(ValueError):
-        b.process_circuit(c, n_shots=10, leakage_detection=True, n_leakage_detection_qubits=1000)
+        b.process_circuit(
+            c, n_shots=10, leakage_detection=True, n_leakage_detection_qubits=1000
+        )
     h = b.process_circuit(c, n_shots=10, leakage_detection=True)
     r = b.get_result(h)
     assert len(r.c_bits) == 4

--- a/tests/integration/backend_test.py
+++ b/tests/integration/backend_test.py
@@ -514,6 +514,9 @@ def test_leakage_detection(
 ) -> None:
     b = authenticated_quum_backend_qa
     c = Circuit(2, 2).H(0).CZ(0, 1).Measure(0, 0).Measure(1, 1)
+
+    with pytest.raises(ValueError):
+        b.process_circuit(c, n_shots=10, leakage_detection=True, n_leakage_detection_qubits=1000)
     h = b.process_circuit(c, n_shots=10, leakage_detection=True)
     r = b.get_result(h)
     assert len(r.c_bits) == 4


### PR DESCRIPTION
# Description

The automatic leakage detection tries to maximise parallelism by using as many spare device qubits as possible for performing leakage detection. Currently when passing `leakage_detection=True` to `process_circuit/s`, it automatically assumes that the user wants to make use of all qubits. This PR adds a new kwarg to `pytket-quantinuum` `n_leakage_detection_qubits` that allows the user to specify fewer qubits. 

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
