### PR TITLE
fix: bad poetry install in docs build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -144,7 +144,7 @@ jobs:
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       run: |
           cd docs && bash ./install.sh
-          for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+          for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry run pip install $w ; done
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20


### PR DESCRIPTION
# Description

The docs build is failing in the relase workflow do to the wheel not being properly installed. I've fixed this by running pip within the poetry env as I've done in https://github.com/CQCL/pytket-qiskit/pull/408

# Related issues
fixes #531 

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
