### PR TITLE
fix: failing docs build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -305,7 +305,7 @@ jobs:
     - name: Install poetry
       run: pip install poetry
     - name: Install extension
-      run: for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+      run: for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry run pip install $w ; done
     - name: Install docs dependencies
       run: |
         cd docs


### PR DESCRIPTION
# Description

Another fix to the docs build on release workflow. Looks like I missed a line in #532 

closes #531 
