### PR TITLE
Allow circuits containuing `OpType.ClExpr` operations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,11 +4,12 @@
 
 # Changelog
 
-## 0.40.0rc0 (November 2024)
+## 0.40.0rc0 (Unreleased)
 
 - Update pytket-qir version requirement to 0.17.
 - Updated pytket version requirement to 1.34.
 - Updated pytket-pecos version requirement to 0.1.31.
+- Allow circuits containing `OpType.ClExpr` operations.
 
 
 ## 0.39.0 (November 2024)

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -113,6 +113,7 @@ _ADDITIONAL_GATES = {
     OpType.SetBits,
     OpType.CopyBits,
     OpType.ClassicalExpBox,
+    OpType.ClExpr,
     OpType.WASM,
 }
 


### PR DESCRIPTION
Tested locally with pytket 1.35.0rc0.
