### PR TITLE
fix: Use API handler for available devices

### DIFF
--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -514,7 +514,7 @@ class QuantinuumAPI:
         return jr
 
     def get_machine_list(self) -> list[dict[str, Any]]:
-        """returns the given list of the available machines
+        """Returns a given list of the available machines
         :return: list of machines
         """
         id_token = self.login()
@@ -631,7 +631,7 @@ class QuantinuumAPIOffline:
         self.submitted: list = []
 
     def get_machine_list(self) -> list[dict[str, Any]]:
-        """returns the given list of the available machines
+        """Returns a given list of the available machines
         :return: list of machines
         """
 

--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -22,7 +22,7 @@ import getpass
 import json
 import time
 from http import HTTPStatus
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import nest_asyncio  # type: ignore
 from requests import Session
@@ -525,7 +525,7 @@ class QuantinuumAPI:
         self._response_check(res, "get machine list")
         jr = res.json()
 
-        return jr
+        return cast(list[dict[str, Any]], jr)
 
 
 OFFLINE_MACHINE_LIST = [

--- a/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -22,7 +22,7 @@ import getpass
 import json
 import time
 from http import HTTPStatus
-from typing import Optional
+from typing import Any, Optional
 
 import nest_asyncio  # type: ignore
 from requests import Session
@@ -513,6 +513,20 @@ class QuantinuumAPI:
         jr: list[dict[str, str]] = res.json()
         return jr
 
+    def get_machine_list(self) -> list[dict[str, Any]]:
+        """returns the given list of the available machines
+        :return: list of machines
+        """
+        id_token = self.login()
+        res = self.session.get(
+            f"{self.url}machine/?config=true",
+            headers={"Authorization": id_token},
+        )
+        self._response_check(res, "get machine list")
+        jr = res.json()
+
+        return jr
+
 
 OFFLINE_MACHINE_LIST = [
     {
@@ -616,8 +630,8 @@ class QuantinuumAPIOffline:
         self._cred_store = None
         self.submitted: list = []
 
-    def _get_machine_list(self) -> Optional[list]:
-        """returns the given list of the avilable machines
+    def get_machine_list(self) -> list[dict[str, Any]]:
+        """returns the given list of the available machines
         :return: list of machines
         """
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -366,17 +366,7 @@ class QuantinuumBackend(Backend):
         :param api_handler: Instance of API handler
         :return: Dictionaries of machine name and number of qubits.
         """
-        id_token = api_handler.login()
-        if api_handler.online:
-            res = requests.get(
-                f"{api_handler.url}machine/?config=true",
-                headers={"Authorization": id_token},
-            )
-            api_handler._response_check(res, "get machine list")
-            jr = res.json()
-        else:
-            jr = api_handler._get_machine_list()  # type: ignore
-        return jr  # type: ignore
+        return api_handler.get_machine_list()
 
     @classmethod
     def _dict_to_backendinfo(


### PR DESCRIPTION
# Description

Fixes the usage of the api handler in the available_devices method by re-using the session of the real handler rather than making a fresh session in the backend.

This will also make it easier to write alternative QuantinuumAPI implementations as a side effect.

# Related issues

Resolves https://github.com/CQCL/pytket-quantinuum/issues/504

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
