### PR TITLE
docs: remove `_tket` link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -102,7 +102,7 @@ the circuit 2-qubit gate count is not reduced after compilation.
 * - [AutoRebase [2]](inv:#*.AutoRebase)
   - [SynthesiseTket](inv:#*.SynthesiseTket)
   - [FullPeepholeOptimise [3]](inv:#*.passes.FullPeepholeOptimise)
-  - [RemoveBarriers](inv:#*pytket._tket.passes.RemoveBarriers)
+  - [RemoveBarriers](inv:#*pytket.passes.RemoveBarriers)
 * - [FlattenRelabelRegistersPass](inv:#*.FlattenRelabelRegistersPass)
   - [NormaliseTK2 [5]](inv:#*.passes.NormaliseTK2)
   - [NormaliseTK2 [5]](inv:#*.passes.NormaliseTK2)


### PR DESCRIPTION
# Description

No longer needed... See https://github.com/CQCL/tket/pull/1721 
