### PR TITLE
Constrain to pytket 1.x.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket >= 1.39.0",
+        "pytket >= 1.39.0, < 2",
         "pytket-qir >= 0.17, < 0.20",
         "requests >= 2.32.2",
         "types-requests",


### PR DESCRIPTION
After the pytket 2.0 release we should be able to change this to ">= 2.0.0" and remove the handling of, and tests involving, `ClassicalExpBox` in this repo.