### PR TITLE
Add max_cost parameter to process_circuits / submit_program

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,12 +2,17 @@
 .. currentmodule:: pytket.extensions.quantinuum
 ```
 
+# Changelog
+
+## Unreleased
+
+- Add `max_cost` parameter to `process_circuits()` and `submit_program()`.
+
 ## 0.46.0 (April 2025)
 
 - Update pytket minimum version requirement to 2.2.0.
 - Update pytket-qir minimum version requirement to 0.22.
 
-# Changelog
 
 ## 0.45.0 (March 2025)
 


### PR DESCRIPTION
# Description

QuantinuumBackend's `process_circuits` and `submit_program` now accept a `max_cost` parameter that is passed along to the remote Quantinuum systems. (It's ignored for the local emulator.)

# Related issues

(No related issues.)

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
