### PR TITLE
Add start-date to fields parsed from job status

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 
 - Update pytket minimum version requirement to 2.4.1.
 - Update pytket-qir minimum version requirement to 0.23.
+- Add `start-date` to fields returned as part of circuit status.
 
 ## 0.47.0 (May 2025)
 

--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1749,6 +1749,7 @@ def _parse_status(response: dict) -> CircuitStatus:
         for k in (
             "name",
             "submit-date",
+            "start-date",
             "result-date",
             "queue-position",
             "cost",


### PR DESCRIPTION
# Description

`_parse_status()` already extracts some of the timestamps that can be sent back:
* `submit-date` for when the circuit was received
* `result-date` for when the circuit had finished running and results were available.

This PR adds another field that gets sent back, `start-date`, for when the circuit actually started to be run.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
