### PR TITLE
fix(): Add `cost-confidence` to status parsing.

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -1767,6 +1767,7 @@ def _parse_status(response: dict) -> CircuitStatus:
             "queue-position",
             "cost",
             "error",
+            "cost-confidence",
             "last-shot",
             "qubits",
             "priority",


### PR DESCRIPTION
> Job Status API should be able to return “cost-confidence” value when it is present - this will be set on Syntax Check jobs and informs the customer if their job is dynamic or not. It will be an integer value between 0 and 100, inclusive.