### PR TITLE
fix: allow to pass a float as max_cost for QuantinuumBackend

### DIFF
--- a/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -995,7 +995,7 @@ class QuantinuumBackend(Backend):
         group: str | None = None,
         wasm_file_handler: WasmFileHandler | None = None,
         pytket_pass: BasePass | None = None,
-        max_cost: int | None = None,
+        max_cost: float | None = None,
         options: dict[str, Any] | None = None,
         request_options: dict[str, Any] | None = None,
         results_selection: list[tuple[str, int]] | None = None,
@@ -1207,7 +1207,7 @@ class QuantinuumBackend(Backend):
 
         language: Language = cast("Language", kwargs.get("language", Language.QIR))
 
-        max_cost = cast("int | None", kwargs.get("max_cost"))
+        max_cost = cast("float | None", kwargs.get("max_cost"))
 
         handle_list = []
 


### PR DESCRIPTION
# Description

Allow to pass a float instead of an int as max cost

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
